### PR TITLE
[Refactor] : redis 에 저장되는 객체 필드 수정으로, token 관리 대상 최소화

### DIFF
--- a/src/main/java/dnd/danverse/domain/jwt/service/JwtTokenReIssueService.java
+++ b/src/main/java/dnd/danverse/domain/jwt/service/JwtTokenReIssueService.java
@@ -19,20 +19,25 @@ public class JwtTokenReIssueService {
   private final JwtTokenProvider jwtTokenProvider;
   private final RedisService redisService;
 
+  /**
+   * Refresh Token 을 이용하여 Access Token 과 Refresh Token 을 재발급 받는다.
+   * @param refreshToken : Client 로 넘어온 Refresh Token
+   * @return : Access Token 과 Refresh Token 을 담은 AccessRefreshTokenDto
+   */
   public AccessRefreshTokenDto reIssueToken(String refreshToken) {
 
     jwtTokenProvider.validateToken(refreshToken);
 
-    Optional<RefreshTokenDto> tokenDto = redisService.isExist(refreshToken);
+    Optional<RefreshTokenDto> tokenDto = redisService.isRefreshTokenExist(refreshToken);
 
-    String newAccessToken = null;
-    String newRefreshToken = null;
+    String newAccessToken;
+    String newRefreshToken;
     // Refresh Token 이 존재하면, 새로운 Access Token 과 Refresh Token 을 발급한다.
     if (tokenDto.isPresent()) {
       String email = tokenDto.get().getEmail();
       newAccessToken = jwtTokenProvider.createAccessToken(email);
       newRefreshToken = jwtTokenProvider.createRefreshToken();
-      redisService.saveRefreshToken(newRefreshToken, email);
+      redisService.saveRefreshToken(email, newRefreshToken);
     } else {
       // Refresh Token 이 존재하지 않으면, Refresh Token 이 Redis 에서도 만료 됨을 의미, 그 만큼(1주일) 오랜 기간 접속하지 않았다.
       throw new IllegalArgumentException("Refresh Token 이 존재하지 않습니다. 새롭게 로그인 해주세요");

--- a/src/main/java/dnd/danverse/domain/jwt/service/JwtTokenReIssueService.java
+++ b/src/main/java/dnd/danverse/domain/jwt/service/JwtTokenReIssueService.java
@@ -1,6 +1,9 @@
 package dnd.danverse.domain.jwt.service;
 
+import static dnd.danverse.global.exception.ErrorCode.JWT_REFRESH_TOKEN_EXPIRED;
+
 import dnd.danverse.domain.jwt.AccessRefreshTokenDto;
+import dnd.danverse.domain.jwt.exception.JwtException;
 import dnd.danverse.global.redis.service.RedisService;
 import dnd.danverse.global.redis.dto.RefreshTokenDto;
 import java.util.Optional;
@@ -40,7 +43,7 @@ public class JwtTokenReIssueService {
       redisService.saveRefreshToken(email, newRefreshToken);
     } else {
       // Refresh Token 이 존재하지 않으면, Refresh Token 이 Redis 에서도 만료 됨을 의미, 그 만큼(1주일) 오랜 기간 접속하지 않았다.
-      throw new IllegalArgumentException("Refresh Token 이 존재하지 않습니다. 새롭게 로그인 해주세요");
+      throw new JwtException(JWT_REFRESH_TOKEN_EXPIRED);
     }
 
     return new AccessRefreshTokenDto(newAccessToken, newRefreshToken);

--- a/src/main/java/dnd/danverse/domain/oauth/service/OAuth2Service.java
+++ b/src/main/java/dnd/danverse/domain/oauth/service/OAuth2Service.java
@@ -39,6 +39,12 @@ public class OAuth2Service {
   private String googleUserInfoUrl;
 
 
+  /**
+   * googleToken 을 통해서 google service 에게 유저 정보를 요청하고,
+   * member 를 생성하거나 업데이트하고, jwt 토큰을 발급한다.
+   * @param googleToken : client 에서 받은 googleToken
+   * @return : jwt 토큰을 담은 response
+   */
   @Transactional
   public ResponseEntity<DataResponse<MemberResponse>> oauth2Login(String googleToken) {
 
@@ -58,7 +64,7 @@ public class OAuth2Service {
     String refreshToken = tokenProvider.createRefreshToken();
 
     // refresh token은 redis server에 저장해야 한다.
-    redisService.saveRefreshToken(refreshToken, member.getEmail());
+    redisService.saveRefreshToken(member.getEmail(), refreshToken);
 
     DataResponse<MemberResponse> response = DataResponse.of(HttpStatus.CREATED,
         "회원 가입 및 로그인 성공", new MemberResponse(member,isSignUp));

--- a/src/main/java/dnd/danverse/global/exception/ErrorCode.java
+++ b/src/main/java/dnd/danverse/global/exception/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
   // JWT (Json Web Token)
   JWT_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "J001", "유효하지 않은 토큰입니다."),
   JWT_EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "J002", "만료된 토큰입니다."),
+  JWT_REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "J003", "만료된 리프레시 토큰입니다."),
 
   // 리소스 요청에 대한 권한이 없는 경우
   RESOURCE_FORBIDDEN(HttpStatus.FORBIDDEN, "R001", "해당 리소스에 대한 권한이 없습니다."),

--- a/src/main/java/dnd/danverse/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/dnd/danverse/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package dnd.danverse.global.exception;
 
 
+import dnd.danverse.domain.jwt.exception.JwtException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -67,6 +68,18 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(BusinessException.class)
   protected ResponseEntity<ErrorResponse> handleBusinessException(final BusinessException e) {
     log.warn("BusinessException", e);
+    final ErrorCode errorCode = e.getErrorCode();
+    final ErrorResponse response = ErrorResponse.of(errorCode);
+    return new ResponseEntity<>(response, HttpStatus.valueOf(errorCode.getStatus()));
+  }
+
+  /**
+   * Refresh Token 을 통해, 토큰 재발급 과정에서 Refresh Token 조차 만료된 경우
+   * 처리하는 Exception Handler .
+   */
+  @ExceptionHandler(JwtException.class)
+  protected ResponseEntity<ErrorResponse> handleJwtException(final JwtException e) {
+    log.warn("JwtException", e);
     final ErrorCode errorCode = e.getErrorCode();
     final ErrorResponse response = ErrorResponse.of(errorCode);
     return new ResponseEntity<>(response, HttpStatus.valueOf(errorCode.getStatus()));

--- a/src/main/java/dnd/danverse/global/redis/dto/RefreshTokenDto.java
+++ b/src/main/java/dnd/danverse/global/redis/dto/RefreshTokenDto.java
@@ -8,11 +8,12 @@ import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
 
 /**
  * Redis 에 저장되는 객체.
  * RefreshToken 은 1주일의 유효시간을 가진다.
- * key = refreshToken , value = email
+ * key = email , value = refreshToken
  * value 에 Indexed 를 생성 함으로써, value 를 통해 조회가 가능하다.
  */
 @Getter
@@ -22,9 +23,10 @@ import org.springframework.data.redis.core.RedisHash;
 public class RefreshTokenDto {
 
   @Id
-  private String refreshToken;
-
   private String email;
+
+  @Indexed
+  private String refreshToken;
 
 }
 

--- a/src/main/java/dnd/danverse/global/redis/repository/RefreshTokenRedisRepository.java
+++ b/src/main/java/dnd/danverse/global/redis/repository/RefreshTokenRedisRepository.java
@@ -2,10 +2,12 @@ package dnd.danverse.global.redis.repository;
 
 
 import dnd.danverse.global.redis.dto.RefreshTokenDto;
+import java.util.Optional;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RefreshTokenRedisRepository extends CrudRepository<RefreshTokenDto, String> {
 
+  Optional<RefreshTokenDto> findByRefreshToken(String refreshToken);
 }

--- a/src/main/java/dnd/danverse/global/redis/service/RedisService.java
+++ b/src/main/java/dnd/danverse/global/redis/service/RedisService.java
@@ -19,20 +19,21 @@ public class RedisService {
 
   /**
    * Refresh Token 을 Redis 에 저장한다.
-   * @param refreshToken : Refresh Token
-   * @param email : email
+   * save 기본 동작은 ID 로 설정된 email 이라는 key 가 존재하면 update, 존재하지 않으면 insert 를 수행한다.
    */
   @Transactional
-  public void saveRefreshToken(String refreshToken, String email) {
-    refreshTokenRedisRepository.save(new RefreshTokenDto(refreshToken, email));
+  public void saveRefreshToken(String email, String refreshToken) {
+    refreshTokenRedisRepository.save(new RefreshTokenDto(email, refreshToken));
   }
 
   /**
    * Refresh Token 이 Redis 에 존재하는지 확인한다.
+   * Redis 에 저장된 객체에서 value 값이 refresh token은 index 로 설정되어 있기 때문에
+   * findByRefreshToken 으로 조회가 가능하다.
    * @param refreshToken : Refresh Token
    * @return : 존재하면 RefreshTokenDto, 존재하지 않으면 Optional.empty()
    */
-  public Optional<RefreshTokenDto> isExist(String refreshToken) {
-    return refreshTokenRedisRepository.findById(refreshToken);
+  public Optional<RefreshTokenDto> isRefreshTokenExist(String refreshToken) {
+    return refreshTokenRedisRepository.findByRefreshToken(refreshToken);
   }
 }


### PR DESCRIPTION
### ✒️ 관련 이슈번호

- Close #36

## 🔑 Key Changes

1. redis에 저장되는 @Id 를 email로 변경
2. 로그인시, 토큰 발급하는 과정에서 email로 key 값이 있으면 해당 객체 덮어쓰기
3. redis에 저장되는 refresh token 필드를 index로 관리함으로써 조회 가능하게 변경

## 📢 To Reviewers

- None