### PR TITLE
[Feat] : 필터링 할 수 있는 이벤트 전체 조회 기능 추가

### DIFF
--- a/src/main/java/dnd/danverse/domain/event/controller/EventController.java
+++ b/src/main/java/dnd/danverse/domain/event/controller/EventController.java
@@ -1,0 +1,41 @@
+package dnd.danverse.domain.event.controller;
+
+import dnd.danverse.domain.event.dto.request.EventCondDto;
+import dnd.danverse.domain.event.dto.response.EventInfoResponse;
+import dnd.danverse.domain.event.service.EventProfileService;
+import dnd.danverse.global.response.DataResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 이벤트를 조회하는 컨트롤러.
+ */
+@RestController
+@RequestMapping("/api/v1/events")
+@RequiredArgsConstructor
+public class EventController {
+
+  private final EventProfileService eventProfileService;
+
+  /**
+   * 이벤트 필터링과, 페이징을 적용한 이벤트 조회.
+   *
+   * @param eventCondDto 이벤트 필터링 조건
+   * @param pageable     페이징 조건
+   * @return 페이징 처리된 이벤트 목록 (모집 기간이 지난 이벤트는 제외)
+   */
+  @GetMapping()
+  public ResponseEntity<DataResponse<Page<EventInfoResponse>>> searchAllEvent(
+      EventCondDto eventCondDto, Pageable pageable) {
+    Page<EventInfoResponse> events = eventProfileService.searchAllEventWithCond(
+        eventCondDto, pageable);
+    return new ResponseEntity<>(DataResponse.of(HttpStatus.OK, "이벤트 조회 성공", events), HttpStatus.OK);
+  }
+
+}

--- a/src/main/java/dnd/danverse/domain/event/dto/request/EventCondDto.java
+++ b/src/main/java/dnd/danverse/domain/event/dto/request/EventCondDto.java
@@ -1,0 +1,26 @@
+package dnd.danverse.domain.event.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 이벤트 필터링 조건을 담는 DTO
+ * ModelAttribute 로써 사용되기 때문에 2가지 중 하나의 방법을 선택하면 된다.
+ * 1. Setter + NoArgsConstructor
+ * 2. Getter + AllArgsConstructor
+ */
+@Getter
+@AllArgsConstructor
+public class EventCondDto {
+
+  /**
+   * 이벤트 지역
+   */
+  private String location;
+
+  /**
+   * 이벤트 유형 (콜라보, 쉐어)
+   */
+  private String type;
+
+}

--- a/src/main/java/dnd/danverse/domain/event/dto/response/EventInfoResponse.java
+++ b/src/main/java/dnd/danverse/domain/event/dto/response/EventInfoResponse.java
@@ -1,0 +1,40 @@
+package dnd.danverse.domain.event.dto.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+import dnd.danverse.domain.event.entitiy.EventType;
+import java.time.LocalDateTime;
+
+import lombok.Getter;
+
+/**
+ * 필터링된 이벤트 전체 조회시 사용되는 응답 DTO
+ */
+@Getter
+public class EventInfoResponse {
+
+  // 이벤트
+  private final Long eventId;
+  private final String title;
+  private final String location;
+  private final EventType type;
+  private final String eventImg;
+  private final LocalDateTime eventDeadLine;
+
+  // 이벤트 주최자
+  private final Long profileId;
+  private final String profileName;
+  private final String profileImg;
+
+  @QueryProjection
+  public EventInfoResponse(Long eventId, String title, String location, EventType type, String eventImg, LocalDateTime eventDeadLine, Long profileId, String profileName, String profileImg) {
+    this.eventId = eventId;
+    this.title = title;
+    this.location = location;
+    this.type = type;
+    this.eventImg = eventImg;
+    this.eventDeadLine = eventDeadLine;
+    this.profileId = profileId;
+    this.profileName = profileName;
+    this.profileImg = profileImg;
+  }
+}

--- a/src/main/java/dnd/danverse/domain/event/entitiy/EventType.java
+++ b/src/main/java/dnd/danverse/domain/event/entitiy/EventType.java
@@ -1,5 +1,8 @@
 package dnd.danverse.domain.event.entitiy;
 
+
+import static org.springframework.util.StringUtils.hasText;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -15,4 +18,26 @@ public enum EventType {
   SHARE("쉐어");
 
   private final String type;
+
+  /**
+   * client 로 부터 넘겨 받은 String type 을 enum 으로 변환
+   * enum에 해당 type이 없을 경우 IllegalArgumentException 발생
+   * null 혹은 "" 빈 문자열일 경우 null 반환하여 동적 쿼리에 활용될 수 있도록 한다.
+   * @param type client로 부터 넘겨 받은 String type
+   * @return enum type
+   */
+  public static EventType of(String type) {
+
+    if (!hasText(type)) {
+      return null;
+    }
+
+    for (EventType eventType : EventType.values()) {
+      if (eventType.getType().equals(type)) {
+        return eventType;
+      }
+    }
+    // TODO : TypeNotSupported Exception 으로 변경 필요 (작성일 : 2023-02-13 03:00)
+    throw new IllegalArgumentException("해당 type은 존재하지 않습니다. type=" + type);
+  }
 }

--- a/src/main/java/dnd/danverse/domain/event/exception/TypeNotSupportException.java
+++ b/src/main/java/dnd/danverse/domain/event/exception/TypeNotSupportException.java
@@ -1,0 +1,14 @@
+package dnd.danverse.domain.event.exception;
+
+import dnd.danverse.global.exception.BusinessException;
+import dnd.danverse.global.exception.ErrorCode;
+
+/**
+ * 이벤트 (콜라보, 쉐어) Type 이 지원되지 않는 경우 발생하는 예외
+ */
+public class TypeNotSupportException extends BusinessException {
+
+  protected TypeNotSupportException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+}

--- a/src/main/java/dnd/danverse/domain/event/repository/EventFilterCustom.java
+++ b/src/main/java/dnd/danverse/domain/event/repository/EventFilterCustom.java
@@ -1,0 +1,15 @@
+package dnd.danverse.domain.event.repository;
+
+import dnd.danverse.domain.event.dto.request.EventCondDto;
+import dnd.danverse.domain.event.dto.response.EventInfoResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+/**
+ * 이벤트를 필터링을 통해서 조회하는 커스텀 인터페이스.
+ */
+public interface EventFilterCustom {
+
+  Page<EventInfoResponse> searchAllEventWithCond(EventCondDto eventCondDto, Pageable pageable);
+
+}

--- a/src/main/java/dnd/danverse/domain/event/repository/EventRepository.java
+++ b/src/main/java/dnd/danverse/domain/event/repository/EventRepository.java
@@ -1,0 +1,15 @@
+package dnd.danverse.domain.event.repository;
+
+import dnd.danverse.domain.event.entitiy.Event;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 이벤트를 조회하는 레포지토리.
+ * JpaRepository 를 상속받아 기본적인 CRUD 메서드를 제공받는다.
+ * EventFilterCustom 을 상속받아 필터링을 위한 커스텀 메서드를 제공받는다.
+ */
+@Repository
+public interface EventRepository extends JpaRepository<Event, Long> , EventFilterCustom{
+
+}

--- a/src/main/java/dnd/danverse/domain/event/repository/EventRepositoryImpl.java
+++ b/src/main/java/dnd/danverse/domain/event/repository/EventRepositoryImpl.java
@@ -1,0 +1,128 @@
+package dnd.danverse.domain.event.repository;
+
+import static dnd.danverse.domain.event.entitiy.QEvent.event;
+import static dnd.danverse.domain.profile.entity.QProfile.profile;
+import static org.aspectj.util.LangUtil.isEmpty;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import dnd.danverse.domain.event.dto.request.EventCondDto;
+import dnd.danverse.domain.event.dto.response.EventInfoResponse;
+import dnd.danverse.domain.event.dto.response.QEventInfoResponse;
+import dnd.danverse.domain.event.entitiy.Event;
+import dnd.danverse.domain.event.entitiy.EventType;
+import java.time.LocalDateTime;
+import java.util.List;
+import javax.persistence.EntityManager;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+
+/**
+ * 이벤트를 필터링을 통해서 조회하는 커스텀 인터페이스를 구현한 구현체
+ * EventRepository 랑 네이밍을 맞추기 위해 Impl 을 붙여서 사용하면 된다.
+ * 그러면 EventRepositoryImpl 는 Bean 으로 관리되며, EventRepository 에서 사용할 수 있다.
+ */
+public class EventRepositoryImpl implements EventFilterCustom {
+
+  private final JPAQueryFactory queryFactory;
+
+  public EventRepositoryImpl(EntityManager em) {
+    this.queryFactory = new JPAQueryFactory(em);
+  }
+
+  /**
+   * 이벤트 필터링과, 페이징을 적용한 이벤트 조회.
+   * @param eventCond 이벤트 필터링 조건
+   * @param pageable 페이징 조건
+   * @return 페이징 처리된 이벤트 목록 (모집 기간이 지난 이벤트는 제외)
+   */
+  public Page<EventInfoResponse> searchAllEventWithCond(EventCondDto eventCond, Pageable pageable) {
+
+    // 현재 시간 이후로 모집 기간이 지난 이벤트는 제외하기 위해
+    LocalDateTime now = LocalDateTime.now();
+
+    // dto 를 통해서 이벤트 및 프로필 정보만 조회
+    List<EventInfoResponse> eventContent = queryFactory
+        .select(new QEventInfoResponse(
+            event.id,
+            event.title,
+            event.location,
+            event.eventType,
+            event.eventImg.imageUrl,
+            event.deadline,
+            profile.id,
+            profile.profileName,
+            profile.profileImg.imageUrl
+        ))
+        .from(event)
+        .join(event.profile, profile)
+        .where(
+            locationEq(eventCond.getLocation()),
+            eventTypeEq(EventType.of(eventCond.getType())),
+            eventAfterNow(now))
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize())
+        .fetch();
+
+
+    return PageableExecutionUtils.getPage(eventContent, pageable, () -> getTotalCount(eventCond));
+  }
+
+  /**
+   * 이벤트 모집 기간이 현재 시간 이후인 이벤트만 조회
+   * @param now 현재 시간
+   * @return BooleanExpression 을 반환하여 동적 쿼리를 만든다.
+   */
+  private BooleanExpression eventAfterNow(LocalDateTime now) {
+    return event.deadline.after(now);
+  }
+
+  /**
+   * 전체 이벤트 갯수를 조회한다.
+   * 원래 countQuery.fetchCount() 를 사용해도 되지만, deprecated 되었다.
+   * PageableExecutionUtils.getPage 의 3번째 파라미터는 LongSupplier 로써 Functional Interface 이다.
+   * Functional Interface 로써 활용하기 위해 따로 메서드로 빼서 사용한다.
+   * 해당 Functional Interface 의 함수 호출 조건은 return 값이 long 이여야 한다.
+   * 추가적으로 전체 갯수를 조회하는 쿼리는 필터링 조건이 모두 이벤트만 조회하면 되기 때문에 프로필 join 을 하지 않는다.
+   * @param eventCond 이벤트 필터링 조건
+   * @return 전체 이벤트 갯수
+   */
+  private long getTotalCount(EventCondDto eventCond) {
+    // 전체 갯수 따로 조회 (필터링 조건은 이벤트만 있기 때문에 카운트 쿼리는 이벤트 대상으로만 한다, join 안한다. )
+    JPAQuery<Event> countQuery = queryFactory
+        .select(event)
+        .from(event)
+        .where(
+            locationEq(eventCond.getLocation()),
+            eventTypeEq(EventType.of(eventCond.getType())));
+
+    // countQuery.fetchCount() 는 deprecated 되었다. 대신 size() 를 사용한다.
+    return countQuery.fetch().size();
+  }
+
+  /**
+   * 이벤트 필터링 조건 중, location 이 null 이거나 빈 문자열이면 null 을 반환한다.
+   * null 을 반환하면 where 절에서 해당 조건은 무시된다.
+   * null 을 반환하지 않으면 해당 조건이 where 절에 추가된다.
+   * @param location 이벤트 필터링 조건 중, location
+   * @return BooleanExpression 을 반환하여 동적 쿼리를 만든다.
+   */
+  private BooleanExpression locationEq(String location) {
+    return isEmpty(location)  ? null : event.location.eq(location);
+  }
+
+  /**
+   * 이벤트 필터링 조건 중, type 이 null 이면 null 을 반환한다.
+   * null 을 반환하면 where 절에서 해당 조건은 무시된다.
+   * null 을 반환하지 않으면 해당 조건이 where 절에 추가된다.
+   * @param eventType 이벤트 필터링 조건 중, type
+   * @return BooleanExpression 을 반환하여 동적 쿼리를 만든다.
+   */
+  private BooleanExpression eventTypeEq(EventType eventType) {
+    return eventType == null ? null : event.eventType.eq(eventType);
+  }
+
+
+}

--- a/src/main/java/dnd/danverse/domain/event/service/EventProfileService.java
+++ b/src/main/java/dnd/danverse/domain/event/service/EventProfileService.java
@@ -1,0 +1,33 @@
+package dnd.danverse.domain.event.service;
+
+import dnd.danverse.domain.event.dto.request.EventCondDto;
+import dnd.danverse.domain.event.dto.response.EventInfoResponse;
+import dnd.danverse.domain.event.repository.EventRepository;
+import dnd.danverse.domain.profile.ProfileRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 이벤트를 조회하는 서비스.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EventProfileService {
+
+  private final ProfileRepository profileRepository;
+  private final EventRepository eventRepository;
+
+  /**
+   * 이벤트 필터링과, 페이징을 적용한 이벤트 조회.
+   * @param eventCondDto 이벤트 필터링 조건
+   * @param pageable 페이징 조건
+   * @return 페이징 처리된 이벤트 목록 (모집 기간이 지난 이벤트는 제외)
+   */
+  public Page<EventInfoResponse> searchAllEventWithCond(EventCondDto eventCondDto, Pageable pageable) {
+    return eventRepository.searchAllEventWithCond(eventCondDto, pageable);
+  }
+}


### PR DESCRIPTION
### ✒️ 관련 이슈번호

- Close #48 

## 🔑 Key Changes

1. querydsl를 활용하여 동적 쿼리와 페이지 네이션을 처리하였습니다.
2. 필터링 조건과 페이징 조건은 url query string을 통해서 받도록 하였습니다.
3. fetchCount()가 deprecated 되어, PageableExecutionUtils.getPage()를 유지한 체 카운트 쿼리 부분을 따로 Functional Interface로써 활용할 수 있도록 하였습니다.

## 📢 To Reviewers
- EventType Enum에서 사용자 정의 Exception을 throw 하는 것은 45번 Issue가 merge 된 후 진행하겠습니다.