### PR TITLE
[Feat] : 공연 정보를 필터링을 통해 조회 기능 추가

### DIFF
--- a/src/main/java/dnd/danverse/domain/performance/controller/PerformanceController.java
+++ b/src/main/java/dnd/danverse/domain/performance/controller/PerformanceController.java
@@ -1,10 +1,15 @@
 package dnd.danverse.domain.performance.controller;
 
+import dnd.danverse.domain.performance.dto.request.PerformCondDto;
 import dnd.danverse.domain.performance.dto.response.ImminentPerformsDto;
+import dnd.danverse.domain.performance.dto.response.PageDto;
+import dnd.danverse.domain.performance.dto.response.PerformInfoResponse;
+import dnd.danverse.domain.performance.service.PerformFilterService;
 import dnd.danverse.domain.performance.service.PerformanceService;
 import dnd.danverse.global.response.DataResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class PerformanceController {
 
   private final PerformanceService performanceService;
+  private final PerformFilterService performFilterService;
 
   /**
    * 공연이 임박한 공연을 조회할 수 있다. 오늘 날짜 기준으로, 최근 공연 4개를 조회할 수 있다.
@@ -31,6 +37,23 @@ public class PerformanceController {
 
     List<ImminentPerformsDto> performs = performanceService.searchImminentPerforms();
     return ResponseEntity.ok(DataResponse.of(HttpStatus.OK, "임박한 공연 조회 성공", performs));
+  }
+
+  /**
+   * 공연 필터링과, 페이징을 적용한 공연 조회.
+   * @param performCondDto 공연 필터링 조건
+   * @param pageable 페이징 조건
+   * @return 페이징 처리된 공연 목록
+   */
+  @GetMapping()
+  public ResponseEntity<DataResponse<PageDto<PerformInfoResponse>>> searchPerformanceWithCond(
+      PerformCondDto performCondDto, Pageable pageable) {
+
+    PageDto<PerformInfoResponse> performInfoResponsePageDto = performFilterService.searchAllPerformWithCond(
+        performCondDto, pageable);
+
+    return new ResponseEntity<>(
+        DataResponse.of(HttpStatus.OK, "공연 조회 성공", performInfoResponsePageDto), HttpStatus.OK);
   }
 
 

--- a/src/main/java/dnd/danverse/domain/performance/dto/request/PerformCondDto.java
+++ b/src/main/java/dnd/danverse/domain/performance/dto/request/PerformCondDto.java
@@ -1,0 +1,34 @@
+package dnd.danverse.domain.performance.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 공연 필터링 조건을 담는 DTO
+ * 날짜, 지역, 장르를 통해 공연을 필터링한다.
+ * ModelAttribute 로써 사용되기 때문에 2가지 중 하나의 방법을 선택하면 된다.
+ * 1. Setter + NoArgsConstructor
+ * 2. Getter + AllArgsConstructor
+ */
+@Getter
+@AllArgsConstructor
+public class PerformCondDto {
+
+  /**
+   * 공연 시작하는 월
+   */
+  private Integer month;
+  /**
+   * 공연 시작하는 일
+   */
+  private Integer day;
+  /**
+   * 공연 지역
+   */
+  private String location;
+  /**
+   * 공연 장르
+   */
+  private String genre;
+
+}

--- a/src/main/java/dnd/danverse/domain/performance/dto/response/PageDto.java
+++ b/src/main/java/dnd/danverse/domain/performance/dto/response/PageDto.java
@@ -1,0 +1,57 @@
+package dnd.danverse.domain.performance.dto.response;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+/**
+ * Pageable 을 통해 조회한 결과를 담는 DTO
+ * @param <T> 조회한 결과의 타입
+ */
+@Getter
+@AllArgsConstructor
+public class PageDto<T> {
+
+  /**
+   * 조회한 결과
+   */
+  private List<T> content;
+  /**
+   * 하나의 페이지에 담기는 요소의 수
+   */
+  private int numberOfElements;
+  /**
+   * 조회한 결과의 시작 위치
+   * 0부터 시작해서 몇 개를 건너뛰었는지를 나타냄
+   */
+  private long offset;
+  /**
+   * 현재 페이지 번호
+   */
+  private int pageNumber;
+  /**
+   * 페이지의 크기 (수용 가능한 content 수)
+   */
+  private int pageSize;
+  /**
+   * 전체 요소의 수
+   */
+  private long totalElements;
+  /**
+   * 전체 페이지의 수
+   */
+  private int totalPages;
+
+  public PageDto(Page<T> page) {
+    this.content = page.getContent();
+    this.numberOfElements = page.getNumberOfElements();
+    this.offset = page.getPageable().getOffset();
+    this.pageNumber = page.getPageable().getPageNumber();
+    this.pageSize = page.getPageable().getPageSize();
+    this.totalElements = page.getTotalElements();
+    this.totalPages = page.getTotalPages();
+  }
+
+
+}

--- a/src/main/java/dnd/danverse/domain/performance/dto/response/PerformInfoResponse.java
+++ b/src/main/java/dnd/danverse/domain/performance/dto/response/PerformInfoResponse.java
@@ -1,0 +1,66 @@
+package dnd.danverse.domain.performance.dto.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+import dnd.danverse.domain.performance.entity.Performance;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.Getter;
+
+/**
+ * 필터링 된 공연 전체 조회시 사용되는 응답 Dto
+ */
+@Getter
+public class PerformInfoResponse {
+
+  // 공연
+  private final Long performId;
+  private final String performTitle;
+  private final String performImg;
+  private final LocalDate performStartDate;
+  private final List<String> performGenres;
+  private final String performLocation;
+
+  // 공연 주최자
+  private final Long profileId;
+  private final String profileImg;
+  private final String profileName;
+
+  @QueryProjection
+  public PerformInfoResponse(Long performId, String performTitle, String performImg, LocalDate performStartDate, List<String> performGenres, String performLocation, Long profileId, String profileImg, String profileName) {
+    this.performId = performId;
+    this.performTitle = performTitle;
+    this.performImg = performImg;
+    this.performStartDate = performStartDate;
+    this.performGenres = performGenres;
+    this.performLocation = performLocation;
+    this.profileId = profileId;
+    this.profileImg = profileImg;
+    this.profileName = profileName;
+  }
+
+  /**
+   * Entity to Dto
+   * @param performance 공연
+   */
+  public PerformInfoResponse (Performance performance) {
+    this.performId = performance.getId();
+    this.performTitle = performance.getTitle();
+    this.performImg = performance.getPerformanceImg().getImageUrl();
+    this.performStartDate = performance.getStartDate();
+    this.performGenres = performance.getPerformGenres();
+    this.performLocation = performance.getLocation();
+    this.profileId = performance.getProfileHost().getId();
+    this.profileImg = performance.getProfileHost().getProfileImg().getImageUrl();
+    this.profileName = performance.getProfileHost().getProfileName();
+  }
+
+  /**
+   * Entity List to Dto List
+   * @param performContent 공연 리스트
+   * @return 공연 정보 응답 Dto 리스트
+   */
+  public static List<PerformInfoResponse> of(List<Performance> performContent) {
+    return performContent.stream().map(PerformInfoResponse::new).collect(Collectors.toList());
+  }
+}

--- a/src/main/java/dnd/danverse/domain/performance/entity/Performance.java
+++ b/src/main/java/dnd/danverse/domain/performance/entity/Performance.java
@@ -123,5 +123,17 @@ public class Performance extends BaseTimeEntity {
     this.description = description;
   }
 
+  /**
+   * 공연 장르 목록을 문자열로 반환한다.
+   * @return 장르 목록
+   */
+  public List<String> getPerformGenres() {
+    List<String> genres = new ArrayList<>();
+    for (PerformGenre genre : performGenres) {
+      genres.add(genre.getGenre());
+    }
+    return genres;
+  }
+
 
 }

--- a/src/main/java/dnd/danverse/domain/performance/repository/PerformFilterCustom.java
+++ b/src/main/java/dnd/danverse/domain/performance/repository/PerformFilterCustom.java
@@ -1,0 +1,16 @@
+package dnd.danverse.domain.performance.repository;
+
+import dnd.danverse.domain.performance.dto.request.PerformCondDto;
+import dnd.danverse.domain.performance.dto.response.PerformInfoResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+/**
+ * 공연을 필터링을 통해서 조회하는 커스텀 인터페이스.
+ */
+public interface PerformFilterCustom {
+
+  Page<PerformInfoResponse> searchAllPerformWithCond(PerformCondDto performCondDto, Pageable pageable);
+
+
+}

--- a/src/main/java/dnd/danverse/domain/performance/repository/PerformanceRepository.java
+++ b/src/main/java/dnd/danverse/domain/performance/repository/PerformanceRepository.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Repository;
  * 공연 관련 데이터를 처리하기 위한 Repository.
  */
 @Repository
-public interface PerformanceRepository extends JpaRepository<Performance, Long> {
+public interface PerformanceRepository extends JpaRepository<Performance, Long>, PerformFilterCustom {
 
   @Query("select p from Performance p where p.startDate >= :now order by p.startDate asc")
   List<Performance> findImminentPerforms(@Param("now") LocalDate now);

--- a/src/main/java/dnd/danverse/domain/performance/repository/PerformanceRepositoryImpl.java
+++ b/src/main/java/dnd/danverse/domain/performance/repository/PerformanceRepositoryImpl.java
@@ -1,0 +1,127 @@
+package dnd.danverse.domain.performance.repository;
+
+import static dnd.danverse.domain.performance.entity.QPerformance.performance;
+import static dnd.danverse.domain.performgenre.entity.QPerformGenre.performGenre;
+import static dnd.danverse.domain.profile.entity.QProfile.profile;
+import static org.aspectj.util.LangUtil.isEmpty;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import dnd.danverse.domain.performance.dto.request.PerformCondDto;
+import dnd.danverse.domain.performance.dto.response.PerformInfoResponse;
+import dnd.danverse.domain.performance.entity.Performance;
+import java.util.List;
+import javax.persistence.EntityManager;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+
+/**
+ * 공연 필터링 조건을 통해 공연 전체를 조회하는 repository
+ */
+public class PerformanceRepositoryImpl implements PerformFilterCustom {
+
+  private final JPAQueryFactory queryFactory;
+
+  public PerformanceRepositoryImpl(EntityManager em) {
+    this.queryFactory = new JPAQueryFactory(em);
+  }
+
+  /**
+   * 공연 필터링 조건을 통해 공연을 조회 (페이징 처리)
+   * @param performCondDto 공연 필터링 조건
+   * @param pageable 페이징 처리
+   * @return 페이징 처리된 공연 정보
+   */
+  @Override
+  public Page<PerformInfoResponse> searchAllPerformWithCond(PerformCondDto performCondDto,
+      Pageable pageable) {
+
+    List<Performance> performContent = queryFactory
+        .select(performance)
+        .from(performance)
+        .join(performance.profileHost, profile).fetchJoin()
+        .join(performance.performGenres, performGenre).fetchJoin()
+        .where(
+            monthEq(performCondDto.getMonth()),
+            dayEq(performCondDto.getDay()),
+            locationEq(performCondDto.getLocation()),
+            genreEq(performCondDto.getGenre())
+        )
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize())
+        .fetch();
+
+    // performContent to performInfoResponse
+    List<PerformInfoResponse> performInfoResponse = PerformInfoResponse.of(performContent);
+
+    return PageableExecutionUtils.getPage(performInfoResponse, pageable,
+        () -> getTotalCount(performCondDto));
+  }
+
+  /**
+   * 필터링 조건이 performance 와 performGenre 에서 모두 사용되므로
+   * countQuery 에서는 join 을 통해 두 테이블을 조인하여 사용 (성능 향상)
+   * profileHost 는 필요없으므로 join 을 사용 안함
+   * @param performCondDto 공연 필터링 조건
+   * @return 공연 전체 개수
+   */
+  private long getTotalCount(PerformCondDto performCondDto) {
+
+    JPAQuery<Performance> countQuery = queryFactory
+        .select(performance)
+        .from(performance)
+        .join(performance.performGenres, performGenre)
+        .where(
+            monthEq(performCondDto.getMonth()),
+            dayEq(performCondDto.getDay()),
+            locationEq(performCondDto.getLocation()),
+            genreEq(performCondDto.getGenre())
+        );
+
+    return countQuery.fetch().size();
+  }
+
+  /**
+   * month 가 일치하는 경우 where 절에 추가
+   * month 가 null 인 경우 where 절에 추가하지 않음
+   * @param month 공연 월
+   * @return month 가 일치하는 경우 where 절에 추가
+   */
+  private BooleanExpression monthEq(Integer month) {
+    return month == null ? null : performance.startDate.month().eq(month);
+  }
+
+  /**
+   * day 가 일치하는 경우 where 절에 추가
+   * day 가 null 인 경우 where 절에 추가하지 않음
+   * @param day 공연 일
+   * @return day 가 일치하는 경우 where 절에 추가
+   */
+  private BooleanExpression dayEq(Integer day) {
+    return day == null ? null : performance.startDate.dayOfMonth().eq(day);
+  }
+
+  /**
+   * location 이 일치하는 경우 where 절에 추가
+   * location 이 null 인 경우 where 절에 추가하지 않음
+   * @param location 공연 장소
+   * @return location 이 일치하는 경우 where 절에 추가
+   */
+  private BooleanExpression locationEq(String location) {
+    return isEmpty(location) ? null : performance.location.eq(location);
+  }
+
+  /**
+   * genre 가 일치하는 경우 where 절에 추가
+   * genre 가 null 인 경우 where 절에 추가하지 않음
+   * @param genre 공연 장르
+   * @return genre 가 일치하는 경우 where 절에 추가
+   */
+  private BooleanExpression genreEq(String genre) {
+    return isEmpty(genre) ? null : performGenre.genre.eq(genre);
+  }
+
+
+}

--- a/src/main/java/dnd/danverse/domain/performance/service/PerformFilterService.java
+++ b/src/main/java/dnd/danverse/domain/performance/service/PerformFilterService.java
@@ -1,0 +1,30 @@
+package dnd.danverse.domain.performance.service;
+
+import dnd.danverse.domain.performance.dto.request.PerformCondDto;
+import dnd.danverse.domain.performance.dto.response.PageDto;
+import dnd.danverse.domain.performance.dto.response.PerformInfoResponse;
+import dnd.danverse.domain.performance.repository.PerformanceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 공연 필터링 조건을 통해 공연 전체를 조회하는 복합 서비스
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PerformFilterService {
+
+  private final PerformanceRepository performanceRepository;
+
+
+  public PageDto<PerformInfoResponse> searchAllPerformWithCond(PerformCondDto performCondDto, Pageable pageable) {
+    Page<PerformInfoResponse> performInfoResponses = performanceRepository.searchAllPerformWithCond(
+        performCondDto, pageable);
+
+    return new PageDto<>(performInfoResponses);
+  }
+}


### PR DESCRIPTION
### ✒️ 관련 이슈번호

- Close #51 

## 🔑 Key Changes

1. 공연 정보글에 대해서 필터링이 가능하다.
2. countQuery를 정말 필요한 영역에 대해서만 계산한다.
3. Page dto를 따로 만듬으로써 페이지 네이션에 필요한 데이터들만 반환하고자 하였다.

## 📢 To Reviewers

- None