### PR TITLE
[Refactor] Token 발급, 재발급 과정 코드 개선

### DIFF
--- a/src/main/java/dnd/danverse/domain/jwt/controller/JwtTokenController.java
+++ b/src/main/java/dnd/danverse/domain/jwt/controller/JwtTokenController.java
@@ -2,9 +2,6 @@ package dnd.danverse.domain.jwt.controller;
 
 import dnd.danverse.domain.jwt.AccessRefreshTokenDto;
 import dnd.danverse.domain.jwt.service.JwtTokenReIssueService;
-import dnd.danverse.domain.member.dto.response.MemberResponse;
-import dnd.danverse.domain.oauth.service.OAuth2Service;
-import dnd.danverse.global.response.DataResponse;
 import dnd.danverse.global.util.CookieUtil;
 import dnd.danverse.global.util.HttpHeaderUtil;
 import dnd.danverse.global.response.MessageResponse;
@@ -15,7 +12,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -29,7 +25,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class JwtTokenController {
 
   private final JwtTokenReIssueService refreshTokenReIssueService;
-  private final OAuth2Service oAuth2Service;
 
   @GetMapping("/jwt/refresh")
   public ResponseEntity<MessageResponse> reIssueToken(@CookieValue(name = "refreshToken") String refreshToken) {
@@ -38,24 +33,14 @@ public class JwtTokenController {
 
     MessageResponse responseDto = MessageResponse.of(HttpStatus.CREATED, "Token 재발급 완료");
 
+    HttpHeaders headers = new HttpHeaders();
     // cookie 에 refresh token 을 저장해야 한다, 그리고 access token 을 header 에 저장해야 한다.
-    HttpHeaders headers = CookieUtil.setRefreshCookie(tokenDto.getNewRefreshToken());
-
+    CookieUtil.setRefreshCookie(headers, tokenDto.getNewRefreshToken());
     HttpHeaderUtil.setAccessToken(headers, tokenDto.getNewAccessToken());
 
     return new ResponseEntity<>(responseDto, headers, HttpStatus.CREATED);
   }
 
-
-  /**
-   * 클라이언트 Request 으로부터 Header 에 있는 Authorization 에 담긴 토큰을 받아서
-   * 회원 가입을 하고, JWT 토큰을 생성하여 반환한다.
-   * @return Header 에 Access Token , Cookie 에 Refresh Token 을 담아서 반환한다.
-   */
-  @GetMapping(value = "/google/login")
-  public ResponseEntity<DataResponse<MemberResponse>> oauth2Login(@RequestHeader("google-token") String googleToken) {
-    return oAuth2Service.oauth2Login(googleToken);
-  }
 
 
 }

--- a/src/main/java/dnd/danverse/domain/jwt/controller/JwtTokenController.java
+++ b/src/main/java/dnd/danverse/domain/jwt/controller/JwtTokenController.java
@@ -2,6 +2,9 @@ package dnd.danverse.domain.jwt.controller;
 
 import dnd.danverse.domain.jwt.AccessRefreshTokenDto;
 import dnd.danverse.domain.jwt.service.JwtTokenReIssueService;
+import dnd.danverse.domain.member.dto.response.MemberResponse;
+import dnd.danverse.domain.oauth.service.OAuth2Service;
+import dnd.danverse.global.response.DataResponse;
 import dnd.danverse.global.util.CookieUtil;
 import dnd.danverse.global.util.HttpHeaderUtil;
 import dnd.danverse.global.response.MessageResponse;
@@ -12,18 +15,20 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/jwt")
+@RequestMapping("/api/v1/oauth/")
 @Slf4j
 public class JwtTokenController {
 
   private final JwtTokenReIssueService refreshTokenReIssueService;
+  private final OAuth2Service oAuth2Service;
 
-  @GetMapping("/refresh")
+  @GetMapping("/jwt/refresh")
   public ResponseEntity<MessageResponse> reIssueToken(@CookieValue(name = "refreshToken") String refreshToken) {
 
     AccessRefreshTokenDto tokenDto = refreshTokenReIssueService.reIssueToken(refreshToken);
@@ -37,5 +42,17 @@ public class JwtTokenController {
 
     return new ResponseEntity<>(responseDto, headers, HttpStatus.CREATED);
   }
+
+
+  /**
+   * 클라이언트 Request 으로부터 Header 에 있는 Authorization 에 담긴 토큰을 받아서
+   * 회원 가입을 하고, JWT 토큰을 생성하여 반환한다.
+   * @return Header 에 Access Token , Cookie 에 Refresh Token 을 담아서 반환한다.
+   */
+  @GetMapping(value = "/google/login")
+  public ResponseEntity<DataResponse<MemberResponse>> oauth2Login(@RequestHeader("google-token") String googleToken) {
+    return oAuth2Service.oauth2Login(googleToken);
+  }
+
 
 }

--- a/src/main/java/dnd/danverse/domain/jwt/controller/JwtTokenController.java
+++ b/src/main/java/dnd/danverse/domain/jwt/controller/JwtTokenController.java
@@ -19,6 +19,9 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * JWT 토큰 관련 컨트롤러
+ */
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/oauth/")

--- a/src/main/java/dnd/danverse/domain/jwt/service/JwtTokenProvider.java
+++ b/src/main/java/dnd/danverse/domain/jwt/service/JwtTokenProvider.java
@@ -94,14 +94,14 @@ public class JwtTokenProvider {
    * @param email 사용자 email
    * @return 생성된 Access Token
    */
-  public String createAccessToken(String email) {
+  public String createAccessToken(String email, Role role) {
     Date now = new Date();
     Date validity = new Date(now.getTime() + ACCESS_TOKEN_EXPIRE_LENGTH_MS);
 
     return Jwts.builder()
         .signWith(secretKey)
         .setSubject(email)
-        .claim(AUTHORITIES_KEY, Role.USER_PROFILE_NO.getAuthority())
+        .claim(AUTHORITIES_KEY, role.getAuthority())
         .setIssuer("danverse")
         .setIssuedAt(now)
         .setExpiration(validity)

--- a/src/main/java/dnd/danverse/domain/jwt/service/JwtTokenProvider.java
+++ b/src/main/java/dnd/danverse/domain/jwt/service/JwtTokenProvider.java
@@ -94,14 +94,14 @@ public class JwtTokenProvider {
    * @param email 사용자 email
    * @return 생성된 Access Token
    */
-  public String createAccessToken(String email, Role role) {
+  public String createAccessToken(String email) {
     Date now = new Date();
     Date validity = new Date(now.getTime() + ACCESS_TOKEN_EXPIRE_LENGTH_MS);
 
     return Jwts.builder()
         .signWith(secretKey)
         .setSubject(email)
-        .claim(AUTHORITIES_KEY, role.getAuthority())
+        .claim(AUTHORITIES_KEY, Role.ROLE_USER.getAuthority())
         .setIssuer("danverse")
         .setIssuedAt(now)
         .setExpiration(validity)

--- a/src/main/java/dnd/danverse/domain/jwt/service/JwtTokenReIssueService.java
+++ b/src/main/java/dnd/danverse/domain/jwt/service/JwtTokenReIssueService.java
@@ -43,9 +43,13 @@ public class JwtTokenReIssueService {
 
     String email = refreshTokenDto.get().getEmail();
 
-    Member member = memberRepository.findByEmail(email).get();
+    Optional<Member> optionalMember = memberRepository.findByEmail(email);
 
-    String newAccessToken = jwtTokenProvider.createAccessToken(email, member.getRole());
+    if (optionalMember.isEmpty()) {
+      throw new JwtException(JWT_REFRESH_TOKEN_EXPIRED);
+    }
+
+    String newAccessToken = jwtTokenProvider.createAccessToken(email, optionalMember.get().getRole());
     String newRefreshToken = jwtTokenProvider.createRefreshToken();
     redisService.saveRefreshToken(email, newRefreshToken);
 

--- a/src/main/java/dnd/danverse/domain/jwt/service/JwtTokenReIssueService.java
+++ b/src/main/java/dnd/danverse/domain/jwt/service/JwtTokenReIssueService.java
@@ -4,6 +4,8 @@ import static dnd.danverse.global.exception.ErrorCode.JWT_REFRESH_TOKEN_EXPIRED;
 
 import dnd.danverse.domain.jwt.AccessRefreshTokenDto;
 import dnd.danverse.domain.jwt.exception.JwtException;
+import dnd.danverse.domain.member.entity.Member;
+import dnd.danverse.domain.member.repository.MemberRepository;
 import dnd.danverse.global.redis.service.RedisService;
 import dnd.danverse.global.redis.dto.RefreshTokenDto;
 import java.util.Optional;
@@ -21,6 +23,7 @@ public class JwtTokenReIssueService {
 
   private final JwtTokenProvider jwtTokenProvider;
   private final RedisService redisService;
+  private final MemberRepository memberRepository;
 
   /**
    * Refresh Token 을 이용하여 Access Token 과 Refresh Token 을 재발급 받는다.
@@ -40,7 +43,9 @@ public class JwtTokenReIssueService {
 
     String email = refreshTokenDto.get().getEmail();
 
-    String newAccessToken = jwtTokenProvider.createAccessToken(email);
+    Member member = memberRepository.findByEmail(email).get();
+
+    String newAccessToken = jwtTokenProvider.createAccessToken(email, member.getRole());
     String newRefreshToken = jwtTokenProvider.createRefreshToken();
     redisService.saveRefreshToken(email, newRefreshToken);
 

--- a/src/main/java/dnd/danverse/domain/jwt/service/JwtTokenReIssueService.java
+++ b/src/main/java/dnd/danverse/domain/jwt/service/JwtTokenReIssueService.java
@@ -1,14 +1,8 @@
 package dnd.danverse.domain.jwt.service;
 
-import static dnd.danverse.global.exception.ErrorCode.JWT_REFRESH_TOKEN_EXPIRED;
-
 import dnd.danverse.domain.jwt.AccessRefreshTokenDto;
-import dnd.danverse.domain.jwt.exception.JwtException;
-import dnd.danverse.domain.member.entity.Member;
-import dnd.danverse.domain.member.repository.MemberRepository;
 import dnd.danverse.global.redis.service.RedisService;
 import dnd.danverse.global.redis.dto.RefreshTokenDto;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,7 +17,6 @@ public class JwtTokenReIssueService {
 
   private final JwtTokenProvider jwtTokenProvider;
   private final RedisService redisService;
-  private final MemberRepository memberRepository;
 
   /**
    * Refresh Token 을 이용하여 Access Token 과 Refresh Token 을 재발급 받는다.
@@ -34,24 +27,11 @@ public class JwtTokenReIssueService {
 
     jwtTokenProvider.validateToken(refreshToken);
 
-    Optional<RefreshTokenDto> refreshTokenDto = redisService.isRefreshTokenExist(refreshToken);
+    RefreshTokenDto refreshTokenDto = redisService.isRefreshTokenExist(refreshToken);
 
-    // redis 에 저장된 refresh token 이 없으면 만료된 것으로 간주한다.
-    if (refreshTokenDto.isEmpty()) {
-      throw new JwtException(JWT_REFRESH_TOKEN_EXPIRED);
-    }
-
-    String email = refreshTokenDto.get().getEmail();
-
-    Optional<Member> optionalMember = memberRepository.findByEmail(email);
-
-    if (optionalMember.isEmpty()) {
-      throw new JwtException(JWT_REFRESH_TOKEN_EXPIRED);
-    }
-
-    String newAccessToken = jwtTokenProvider.createAccessToken(email, optionalMember.get().getRole());
+    String newAccessToken = jwtTokenProvider.createAccessToken(refreshTokenDto.getEmail());
     String newRefreshToken = jwtTokenProvider.createRefreshToken();
-    redisService.saveRefreshToken(email, newRefreshToken);
+    redisService.saveRefreshToken(refreshTokenDto.getEmail(), newRefreshToken);
 
     return new AccessRefreshTokenDto(newAccessToken, newRefreshToken);
   }

--- a/src/main/java/dnd/danverse/domain/member/controller/MemberController.java
+++ b/src/main/java/dnd/danverse/domain/member/controller/MemberController.java
@@ -2,10 +2,19 @@ package dnd.danverse.domain.member.controller;
 
 
 import dnd.danverse.domain.jwt.service.SessionUser;
+import dnd.danverse.domain.member.dto.response.MemberResponse;
+import dnd.danverse.domain.oauth.dto.OAuth2LoginResponseDTO;
+import dnd.danverse.domain.oauth.service.OAuth2Service;
+import dnd.danverse.global.response.DataResponse;
+import dnd.danverse.global.util.CookieUtil;
+import dnd.danverse.global.util.HttpHeaderUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,7 +26,28 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/member")
 public class MemberController {
 
+  private final OAuth2Service oAuth2Service;
 
+  /**
+   * 클라이언트 Request 으로부터 Header 에 있는 Authorization 에 담긴 토큰을 받아서
+   * 회원 가입을 하고, JWT 토큰을 생성하여 반환한다.
+   * @return Header 에 Access Token , Cookie 에 Refresh Token 을 담아서 반환한다.
+   */
+  @GetMapping(value = "/oauth/google/login")
+  public ResponseEntity<DataResponse<MemberResponse>> oauth2Login(@RequestHeader("google-token") String googleToken) {
+    OAuth2LoginResponseDTO responseDto = oAuth2Service.oauth2Login(googleToken);
+
+    HttpHeaders headers = new HttpHeaders();
+    CookieUtil.setRefreshCookie(headers, responseDto.getRefreshToken());
+    HttpHeaderUtil.setAccessToken(headers, responseDto.getAccessToken());
+
+    return ResponseEntity
+        .status(HttpStatus.CREATED)
+        .headers(headers)
+        .body(DataResponse.of(HttpStatus.CREATED,
+            "회원 가입 및 로그인 성공", responseDto.getMemberResponse()));
+
+  }
 
   @GetMapping("resource")
   public ResponseEntity<String> resource(@AuthenticationPrincipal SessionUser user) {

--- a/src/main/java/dnd/danverse/domain/member/controller/MemberController.java
+++ b/src/main/java/dnd/danverse/domain/member/controller/MemberController.java
@@ -1,33 +1,22 @@
 package dnd.danverse.domain.member.controller;
 
-import dnd.danverse.global.response.DataResponse;
-import dnd.danverse.domain.member.dto.response.MemberResponse;
-import dnd.danverse.domain.oauth.service.OAuth2Service;
+
 import dnd.danverse.domain.jwt.service.SessionUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * 회원 관련 컨트롤러
+ */
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/member")
+@RequestMapping("/api/v1/member")
 public class MemberController {
 
-  private final OAuth2Service oAuth2Service;
-
-  /**
-   * 클라이언트 Request 으로부터 Header 에 있는 Authorization 에 담긴 토큰을 받아서
-   * 회원 가입을 하고, JWT 토큰을 생성하여 반환한다.
-   * @return Header 에 Access Token , Cookie 에 Refresh Token 을 담아서 반환한다.
-   */
-  @GetMapping(value = "/oauth/google/login")
-  public ResponseEntity<DataResponse<MemberResponse>> oauth2Login(@RequestHeader("google-token") String googleToken) {
-    return oAuth2Service.oauth2Login(googleToken);
-  }
 
 
   @GetMapping("resource")

--- a/src/main/java/dnd/danverse/domain/member/controller/MemberController.java
+++ b/src/main/java/dnd/danverse/domain/member/controller/MemberController.java
@@ -41,12 +41,8 @@ public class MemberController {
     CookieUtil.setRefreshCookie(headers, responseDto.getRefreshToken());
     HttpHeaderUtil.setAccessToken(headers, responseDto.getAccessToken());
 
-    return ResponseEntity
-        .status(HttpStatus.CREATED)
-        .headers(headers)
-        .body(DataResponse.of(HttpStatus.CREATED,
-            "회원 가입 및 로그인 성공", responseDto.getMemberResponse()));
-
+    return new ResponseEntity<>(DataResponse.of(HttpStatus.CREATED,
+        "회원 가입 및 로그인 성공", responseDto.getMemberResponse()), headers, HttpStatus.CREATED);
   }
 
   @GetMapping("resource")

--- a/src/main/java/dnd/danverse/domain/member/dto/response/MemberResponse.java
+++ b/src/main/java/dnd/danverse/domain/member/dto/response/MemberResponse.java
@@ -58,7 +58,7 @@ public class MemberResponse {
    */
   public MemberResponse(SignUpResult signUpResult) {
     Member member = signUpResult.getMember();
-    Profile profile = signUpResult.getProfile();
+    Profile resultProfile = signUpResult.getProfile();
 
     this.id = member.getId();
     this.name = member.getName();
@@ -66,7 +66,7 @@ public class MemberResponse {
     this.picture = member.getSocialImg();
     this.role = member.getRole().getAuthority();
     this.isSignUp = signUpResult.isSignUp();
-    this.profile = profile != null ? new ProfileInfoDto(profile) : null;
+    this.profile = resultProfile != null ? new ProfileInfoDto(resultProfile) : null;
   }
 
 

--- a/src/main/java/dnd/danverse/domain/member/dto/response/MemberResponse.java
+++ b/src/main/java/dnd/danverse/domain/member/dto/response/MemberResponse.java
@@ -32,7 +32,7 @@ public class MemberResponse {
   /**
    * 사용자의 소셜 프로필 이미지.
    */
-  private String picture;
+  private String imgUrl;
 
   /**
    * 사용자의 권한.
@@ -63,7 +63,7 @@ public class MemberResponse {
     this.id = member.getId();
     this.name = member.getName();
     this.email = member.getEmail();
-    this.picture = member.getSocialImg();
+    this.imgUrl = member.getSocialImg();
     this.role = member.getRole().getAuthority();
     this.isSignUp = signUpResult.isSignUp();
     this.profile = resultProfile != null ? new ProfileInfoDto(resultProfile) : null;

--- a/src/main/java/dnd/danverse/domain/member/dto/response/MemberResponse.java
+++ b/src/main/java/dnd/danverse/domain/member/dto/response/MemberResponse.java
@@ -1,6 +1,6 @@
 package dnd.danverse.domain.member.dto.response;
 
-import dnd.danverse.domain.member.entity.Member;
+import dnd.danverse.domain.member.service.SignUpResult;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -45,15 +45,15 @@ public class MemberResponse {
 
   /**
    * Member Entity 를 MemberResponse 로 변환하는 메소드
-   * @param member Member Entity
+   * @param signUpResult 회원가입 결과
    */
-  public MemberResponse(Member member, boolean isSignUp) {
-    this.id = member.getId();
-    this.name = member.getName();
-    this.email = member.getEmail();
-    this.picture = member.getSocialImg();
-    this.role = member.getRole().getAuthority();
-    this.isSignUp = isSignUp;
+  public MemberResponse(SignUpResult signUpResult) {
+    this.id = signUpResult.getMember().getId();
+    this.name = signUpResult.getMember().getName();
+    this.email = signUpResult.getMember().getEmail();
+    this.picture = signUpResult.getMember().getSocialImg();
+    this.role = signUpResult.getMember().getRole().getAuthority();
+    this.isSignUp = signUpResult.isSignUp();
   }
 
 

--- a/src/main/java/dnd/danverse/domain/member/dto/response/MemberResponse.java
+++ b/src/main/java/dnd/danverse/domain/member/dto/response/MemberResponse.java
@@ -1,6 +1,9 @@
 package dnd.danverse.domain.member.dto.response;
 
+import dnd.danverse.domain.member.entity.Member;
 import dnd.danverse.domain.member.service.SignUpResult;
+import dnd.danverse.domain.profile.dto.response.ProfileInfoDto;
+import dnd.danverse.domain.profile.entity.Profile;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -44,16 +47,26 @@ public class MemberResponse {
   private boolean isSignUp;
 
   /**
-   * Member Entity 를 MemberResponse 로 변환하는 메소드
-   * @param signUpResult 회원가입 결과
+   * 사용자의 프로필 정보를 담는 Dto
+   */
+  private ProfileInfoDto profile;
+
+  /**
+   * SignUpResult 가 가지고 있는 member , profile 정보를 이용하여 MemberResponse 를 생성한다.
+   * 프로필을 아직 등록하지 않은 사용자의 경우, profile 은 null 이다.
+   * @param signUpResult 회원가입 결과를 담은 객체
    */
   public MemberResponse(SignUpResult signUpResult) {
-    this.id = signUpResult.getMember().getId();
-    this.name = signUpResult.getMember().getName();
-    this.email = signUpResult.getMember().getEmail();
-    this.picture = signUpResult.getMember().getSocialImg();
-    this.role = signUpResult.getMember().getRole().getAuthority();
+    Member member = signUpResult.getMember();
+    Profile profile = signUpResult.getProfile();
+
+    this.id = member.getId();
+    this.name = member.getName();
+    this.email = member.getEmail();
+    this.picture = member.getSocialImg();
+    this.role = member.getRole().getAuthority();
     this.isSignUp = signUpResult.isSignUp();
+    this.profile = profile != null ? new ProfileInfoDto(profile) : null;
   }
 
 

--- a/src/main/java/dnd/danverse/domain/member/entity/Member.java
+++ b/src/main/java/dnd/danverse/domain/member/entity/Member.java
@@ -2,13 +2,17 @@ package dnd.danverse.domain.member.entity;
 
 import dnd.danverse.domain.common.BaseTimeEntity;
 import dnd.danverse.domain.oauth.info.OAuth2Provider;
+import dnd.danverse.domain.profile.entity.Profile;
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.OneToOne;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -38,6 +42,12 @@ public class Member extends BaseTimeEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "MEMBER_SEQ_GENERATOR")
   private Long id;
+
+  /**
+   * 사용자의 프로필 정보. OneToOne 관계이며, Member 의 프로필 정보를 조회할 때 사용한다.
+   */
+  @OneToOne(mappedBy = "member", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
+  private Profile profile;
 
   /**
    * 사용자의 이름.

--- a/src/main/java/dnd/danverse/domain/member/entity/Role.java
+++ b/src/main/java/dnd/danverse/domain/member/entity/Role.java
@@ -10,8 +10,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum Role {
 
-  USER_PROFILE_YES("ROLE_USER_PROFILE_YES"),
-  USER_PROFILE_NO("ROLE_USER_PROFILE_NO");
+  ROLE_USER("ROLE_USER");
 
   private final String authority;
 }

--- a/src/main/java/dnd/danverse/domain/member/repository/MemberRepository.java
+++ b/src/main/java/dnd/danverse/domain/member/repository/MemberRepository.java
@@ -3,6 +3,8 @@ package dnd.danverse.domain.member.repository;
 import dnd.danverse.domain.member.entity.Member;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 /**
@@ -13,5 +15,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
   Optional<Member> findByEmail(String email);
 
-  Optional<Member> findByUsername(String oauth2Id);
+  @Query("select m from Member m left join fetch m.profile p where m.username = :oauth2Id")
+  Optional<Member> findByUsername(@Param("oauth2Id") String oauth2Id);
 }

--- a/src/main/java/dnd/danverse/domain/member/service/MemberSignUpService.java
+++ b/src/main/java/dnd/danverse/domain/member/service/MemberSignUpService.java
@@ -24,56 +24,47 @@ public class MemberSignUpService {
   private final MemberRepository memberRepository;
 
   /**
-   * 구글 로그인 정보를 받아서 회원가입을 진행한다.
-   * @param userInfo 구글에서 제공 받은 사용자 정보
-   * @return 회원가입이 완료된 사용자 정보
-   */
-  @Transactional
-  public Member signUp(OAuth2UserInfo userInfo) {
-    Member member = Member.builder()
-        .name(userInfo.getName())
-        .email(userInfo.getEmail())
-        .username(userInfo.getId())
-        .password(userInfo.getName() + userInfo.getId())
-        .socialImg(userInfo.getImageUrl())
-        .role(Role.USER_PROFILE_NO)
-        .oauth2Provider(userInfo.getOauth2Provider())
-        .build();
-
-    return memberRepository.save(member);
-  }
-
-
-  /**
-   * 계정이 이미 존재 한다면 프로필 정보를 업데이트 한다.
-   * 존재하지 않는다면 회원가입을 진행한다.
+   * 계정이 이미 존재 한다면 프로필 정보를 업데이트 한다. 존재하지 않는다면 회원가입을 진행한다.
+   *
    * @param userInfo 소셜 로그인 정보
    * @return 회원가입이 완료된 사용자 정보
    */
   @Transactional
-  public Map<String, Object> signUpOrUpdate(OAuth2UserInfo userInfo) {
+  public SignUpResult signUpOrUpdate(OAuth2UserInfo userInfo) {
     Optional<Member> optionalMember = memberRepository.findByUsername(userInfo.getId());
-    Map<String, Object> map = new ConcurrentHashMap<>();
 
     // 존재한다면 프로필도 업데이트
     if (optionalMember.isPresent()) {
       Member member = optionalMember.get();
-      member.updateInfo(userInfo.getEmail(), userInfo.getName(), userInfo.getImageUrl());
-      map.put("member", member);
-      map.put("isSignUp", false);
-      return map;
+      updateMemberInfo(userInfo, member);
+      return new SignUpResult(member, false);
     }
     // 존재하지 않는다면 회원가입
     Member member = signUp(userInfo);
-    map.put("member", member);
-    map.put("isSignUp", true);
-    return map;
+    return new SignUpResult(member, true);
   }
 
+  /**
+   * 회원 정보를 업데이트 한다.
+   * @param userInfo 소셜 로그인 정보
+   * @param member 회원 정보
+   */
+  private void updateMemberInfo(OAuth2UserInfo userInfo, Member member) {
+    member.updateInfo(userInfo.getEmail(), userInfo.getName(), userInfo.getImageUrl());
+  }
 
+  /**
+   * 구글 로그인 정보를 받아서 회원가입을 진행한다.
+   *
+   * @param userInfo 구글에서 제공 받은 사용자 정보
+   * @return 회원가입이 완료된 사용자 정보
+   */
+  private Member signUp(OAuth2UserInfo userInfo) {
 
+    Member member = userInfo.toEntity();
 
-
+    return memberRepository.save(member);
+  }
 
 
 }

--- a/src/main/java/dnd/danverse/domain/member/service/MemberSignUpService.java
+++ b/src/main/java/dnd/danverse/domain/member/service/MemberSignUpService.java
@@ -1,12 +1,9 @@
 package dnd.danverse.domain.member.service;
 
 import dnd.danverse.domain.member.entity.Member;
-import dnd.danverse.domain.member.entity.Role;
 import dnd.danverse.domain.member.repository.MemberRepository;
 import dnd.danverse.domain.oauth.info.OAuth2UserInfo;
-import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -37,7 +34,7 @@ public class MemberSignUpService {
     if (optionalMember.isPresent()) {
       Member member = optionalMember.get();
       updateMemberInfo(userInfo, member);
-      return new SignUpResult(member, false);
+      return new SignUpResult(member, member.getProfile() ,false);
     }
     // 존재하지 않는다면 회원가입
     Member member = signUp(userInfo);

--- a/src/main/java/dnd/danverse/domain/member/service/MemberSignUpService.java
+++ b/src/main/java/dnd/danverse/domain/member/service/MemberSignUpService.java
@@ -34,7 +34,7 @@ public class MemberSignUpService {
     if (optionalMember.isPresent()) {
       Member member = optionalMember.get();
       updateMemberInfo(userInfo, member);
-      return new SignUpResult(member, member.getProfile() ,false);
+      return new SignUpResult(member, false);
     }
     // 존재하지 않는다면 회원가입
     Member member = signUp(userInfo);

--- a/src/main/java/dnd/danverse/domain/member/service/SignUpResult.java
+++ b/src/main/java/dnd/danverse/domain/member/service/SignUpResult.java
@@ -4,35 +4,25 @@ import dnd.danverse.domain.member.entity.Member;
 import dnd.danverse.domain.profile.entity.Profile;
 import lombok.Getter;
 
+/**
+ * Member 데이터와 회원가입 여부, Profile 데이터를 반환하기 위한 객체
+ */
 @Getter
 public class SignUpResult {
 
   private final Member member;
   private final boolean isSignUp;
-
   private final Profile profile;
 
   /**
    * 프로필이 있는 사용자의 경우, 로그인 후 프로필 정보를 반환한다.
-   * @param member 회원 정보
-   * @param profile 프로필 정보
-   * @param isSignUp 회원가입 여부
-   */
-  public SignUpResult(Member member, Profile profile, boolean isSignUp) {
-    this.member = member;
-    this.isSignUp = isSignUp;
-    this.profile = profile;
-  }
-
-  /**
-   * 프로필이 없는 사용자의 경우, 로그인 후 프로필 정보를 반환하지 않는다.
    * @param member 회원 정보
    * @param isSignUp 회원가입 여부
    */
   public SignUpResult(Member member, boolean isSignUp) {
     this.member = member;
     this.isSignUp = isSignUp;
-    this.profile = null;
+    this.profile = member.getProfile();
   }
 
   /**

--- a/src/main/java/dnd/danverse/domain/member/service/SignUpResult.java
+++ b/src/main/java/dnd/danverse/domain/member/service/SignUpResult.java
@@ -1,7 +1,7 @@
 package dnd.danverse.domain.member.service;
 
 import dnd.danverse.domain.member.entity.Member;
-import java.util.Optional;
+import dnd.danverse.domain.profile.entity.Profile;
 import lombok.Getter;
 
 @Getter
@@ -10,9 +10,37 @@ public class SignUpResult {
   private final Member member;
   private final boolean isSignUp;
 
+  private final Profile profile;
+
+  /**
+   * 프로필이 있는 사용자의 경우, 로그인 후 프로필 정보를 반환한다.
+   * @param member 회원 정보
+   * @param profile 프로필 정보
+   * @param isSignUp 회원가입 여부
+   */
+  public SignUpResult(Member member, Profile profile, boolean isSignUp) {
+    this.member = member;
+    this.isSignUp = isSignUp;
+    this.profile = profile;
+  }
+
+  /**
+   * 프로필이 없는 사용자의 경우, 로그인 후 프로필 정보를 반환하지 않는다.
+   * @param member 회원 정보
+   * @param isSignUp 회원가입 여부
+   */
   public SignUpResult(Member member, boolean isSignUp) {
     this.member = member;
     this.isSignUp = isSignUp;
+    this.profile = null;
+  }
+
+  /**
+   * 회원가입 여부를 반환한다.
+   * @return 회원가입 여부
+   */
+  public boolean isSignUp() {
+    return isSignUp;
   }
 
 }

--- a/src/main/java/dnd/danverse/domain/member/service/SignUpResult.java
+++ b/src/main/java/dnd/danverse/domain/member/service/SignUpResult.java
@@ -1,0 +1,18 @@
+package dnd.danverse.domain.member.service;
+
+import dnd.danverse.domain.member.entity.Member;
+import java.util.Optional;
+import lombok.Getter;
+
+@Getter
+public class SignUpResult {
+
+  private final Member member;
+  private final boolean isSignUp;
+
+  public SignUpResult(Member member, boolean isSignUp) {
+    this.member = member;
+    this.isSignUp = isSignUp;
+  }
+
+}

--- a/src/main/java/dnd/danverse/domain/oauth/dto/OAuth2LoginResponseDTO.java
+++ b/src/main/java/dnd/danverse/domain/oauth/dto/OAuth2LoginResponseDTO.java
@@ -1,0 +1,17 @@
+package dnd.danverse.domain.oauth.dto;
+
+import dnd.danverse.domain.member.dto.response.MemberResponse;
+import lombok.Getter;
+
+@Getter
+public class OAuth2LoginResponseDTO {
+  private final String accessToken;
+  private final String refreshToken;
+  private final MemberResponse memberResponse;
+
+  public OAuth2LoginResponseDTO(String accessToken, String refreshToken, MemberResponse memberResponse) {
+    this.accessToken = accessToken;
+    this.refreshToken = refreshToken;
+    this.memberResponse = memberResponse;
+  }
+}

--- a/src/main/java/dnd/danverse/domain/oauth/info/OAuth2UserInfo.java
+++ b/src/main/java/dnd/danverse/domain/oauth/info/OAuth2UserInfo.java
@@ -42,7 +42,7 @@ public abstract class OAuth2UserInfo {
         .username(this.getId())
         .password(this.getName().concat(this.getId()))
         .socialImg(this.getImageUrl())
-        .role(Role.USER_PROFILE_NO)
+        .role(Role.ROLE_USER)
         .oauth2Provider(this.getOauth2Provider())
         .build();
   }

--- a/src/main/java/dnd/danverse/domain/oauth/info/OAuth2UserInfo.java
+++ b/src/main/java/dnd/danverse/domain/oauth/info/OAuth2UserInfo.java
@@ -1,5 +1,7 @@
 package dnd.danverse.domain.oauth.info;
 
+import dnd.danverse.domain.member.entity.Member;
+import dnd.danverse.domain.member.entity.Role;
 import java.util.Map;
 
 /**
@@ -31,6 +33,18 @@ public abstract class OAuth2UserInfo {
 
   public OAuth2Provider getOauth2Provider() {
     return oauth2Provider;
+  }
+
+  public Member toEntity() {
+    return Member.builder()
+        .name(this.getName())
+        .email(this.getEmail())
+        .username(this.getId())
+        .password(this.getName().concat(this.getId()))
+        .socialImg(this.getImageUrl())
+        .role(Role.USER_PROFILE_NO)
+        .oauth2Provider(this.getOauth2Provider())
+        .build();
   }
 }
 

--- a/src/main/java/dnd/danverse/domain/oauth/service/OAuth2Service.java
+++ b/src/main/java/dnd/danverse/domain/oauth/service/OAuth2Service.java
@@ -1,5 +1,6 @@
 package dnd.danverse.domain.oauth.service;
 
+import dnd.danverse.domain.member.entity.Role;
 import dnd.danverse.domain.member.service.SignUpResult;
 import dnd.danverse.domain.oauth.dto.OAuth2LoginResponseDTO;
 import dnd.danverse.domain.oauth.info.OAuth2UserInfo;
@@ -43,7 +44,7 @@ public class OAuth2Service {
     OAuth2UserInfo userInfo = getUserInfoFromGoogle(googleToken);
     SignUpResult signUpResult = memberSignUpService.signUpOrUpdate(userInfo);
     String email = getEmail(signUpResult);
-    String accessToken = createAccessToken(email);
+    String accessToken = createAccessToken(email, signUpResult.getMember().getRole());
     String refreshToken = createRefreshToken();
     saveRefreshTokenToRedis(email, refreshToken);
 
@@ -61,8 +62,8 @@ public class OAuth2Service {
     return tokenProvider.createRefreshToken();
   }
 
-  private String createAccessToken(String email) {
-    return tokenProvider.createAccessToken(email);
+  private String createAccessToken(String email, Role role) {
+    return tokenProvider.createAccessToken(email, role);
   }
 
   private OAuth2UserInfo getUserInfoFromGoogle(String googleToken) {

--- a/src/main/java/dnd/danverse/domain/oauth/service/OAuth2Service.java
+++ b/src/main/java/dnd/danverse/domain/oauth/service/OAuth2Service.java
@@ -1,29 +1,21 @@
 package dnd.danverse.domain.oauth.service;
 
+import dnd.danverse.domain.member.service.SignUpResult;
+import dnd.danverse.domain.oauth.dto.OAuth2LoginResponseDTO;
 import dnd.danverse.domain.oauth.info.OAuth2UserInfo;
-import dnd.danverse.global.util.HttpHeaderUtil;
-import dnd.danverse.global.response.DataResponse;
 import dnd.danverse.domain.jwt.service.JwtTokenProvider;
 import dnd.danverse.global.redis.service.RedisService;
-import dnd.danverse.domain.member.entity.Member;
 import dnd.danverse.domain.member.dto.response.MemberResponse;
 import dnd.danverse.domain.member.service.MemberSignUpService;
-import dnd.danverse.global.util.CookieUtil;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * OAuth2 로그인을 위한 서비스 클래스.
- * 1. google 에서 받은 googleToken 을 통해서 google service 에게 유저 정보를 요청한다.
- * 2. google service 에서 받은 유저 정보를 통해서 member 를 저장하거나 업데이트한다.
- * 3. 생성된 member 를 통해서 jwt 토큰을 생성한다.
- * 4. 생성된 jwt 토큰을 쿠키와 헤더에 담아서 클라이언트에게 전달한다.
+ * OAuth2 로그인을 위한 서비스 클래스. 1. google 에서 받은 googleToken 을 통해서 google service 에게 유저 정보를 요청한다. 2.
+ * google service 에서 받은 유저 정보를 통해서 member 를 저장하거나 업데이트한다. 3. 생성된 member 를 통해서 jwt 토큰을 생성한다. 4. 생성된
+ * jwt 토큰을 쿠키와 헤더에 담아서 클라이언트에게 전달한다.
  */
 @Service
 @Transactional(readOnly = true)
@@ -40,43 +32,53 @@ public class OAuth2Service {
 
 
   /**
-   * googleToken 을 통해서 google service 에게 유저 정보를 요청하고,
-   * member 를 생성하거나 업데이트하고, jwt 토큰을 발급한다.
+   * googleToken 을 통해서 google service 에게 유저 정보를 요청하고, member 를 생성하거나 업데이트하고, jwt 토큰을 발급한다.
+   *
    * @param googleToken : client 에서 받은 googleToken
    * @return : jwt 토큰을 담은 response
    */
   @Transactional
-  public ResponseEntity<DataResponse<MemberResponse>> oauth2Login(String googleToken) {
+  public OAuth2LoginResponseDTO oauth2Login(String googleToken) {
 
-    String urlInfo = String.format(googleUserInfoUrl, googleToken);
+    OAuth2UserInfo userInfo = getUserInfoFromGoogle(googleToken);
+    SignUpResult signUpResult = memberSignUpService.signUpOrUpdate(userInfo);
+    String email = getEmail(signUpResult);
+    String accessToken = createAccessToken(email);
+    String refreshToken = createRefreshToken();
+    saveRefreshTokenToRedis(email, refreshToken);
 
-    // httpRequestUtil 를 통해서 google service 에게 googleToken 을 보내자.
-    OAuth2UserInfo userInfo = httpSocialLoginRequest.getUserInfo(urlInfo);
-
-    // google 에서 받은 정보를 통해서 member 를 생성하거나 업데이트하자.
-    Map<String, Object> map = memberSignUpService.signUpOrUpdate(userInfo);
-    Member member = (Member) map.get("member");
-    boolean isSignUp = (boolean) map.get("isSignUp");
-
-    // JWT 토큰을 발급해야 한다.
-    // 해당 정보를 통해서 회원 가입을 진행하며, 회원 가입이 완료되면 jwt 토큰을 만들어서 response 에 넣어준다.
-    String accessToken = tokenProvider.createAccessToken(member.getEmail());
-    String refreshToken = tokenProvider.createRefreshToken();
-
-    // refresh token은 redis server에 저장해야 한다.
-    redisService.saveRefreshToken(member.getEmail(), refreshToken);
-
-    DataResponse<MemberResponse> response = DataResponse.of(HttpStatus.CREATED,
-        "회원 가입 및 로그인 성공", new MemberResponse(member,isSignUp));
-
-    // cookie 에 refresh token 을 저장해야 한다, 그리고 access token 을 header 에 저장해야 한다.
-    HttpHeaders httpHeaders = CookieUtil.setRefreshCookie(refreshToken);
-    HttpHeaderUtil.setAccessToken(httpHeaders, accessToken);
-
-    return new ResponseEntity<>(response, httpHeaders, HttpStatus.CREATED);
+    MemberResponse memberResponse = new MemberResponse(signUpResult);
+    return new OAuth2LoginResponseDTO(accessToken, refreshToken, memberResponse);
   }
 
 
+
+  private void saveRefreshTokenToRedis(String email,String refreshToken) {
+    redisService.saveRefreshToken(email, refreshToken);
+  }
+
+  private String createRefreshToken() {
+    return tokenProvider.createRefreshToken();
+  }
+
+  private String createAccessToken(String email) {
+    return tokenProvider.createAccessToken(email);
+  }
+
+  private OAuth2UserInfo getUserInfoFromGoogle(String googleToken) {
+    String urlInfo = String.format(googleUserInfoUrl, googleToken);
+    return httpSocialLoginRequest.getUserInfo(urlInfo);
+  }
+
+  /**
+   * SignUpResult 에서 email 을 추출한다.
+   *
+   * @param signUpResult 회원 가입 결과
+   * @return email
+   */
+  private String getEmail(SignUpResult signUpResult) {
+    return signUpResult.getMember().getEmail();
+  }
 
 
 }

--- a/src/main/java/dnd/danverse/domain/oauth/service/OAuth2Service.java
+++ b/src/main/java/dnd/danverse/domain/oauth/service/OAuth2Service.java
@@ -19,7 +19,6 @@ import org.springframework.transaction.annotation.Transactional;
  * jwt 토큰을 쿠키와 헤더에 담아서 클라이언트에게 전달한다.
  */
 @Service
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class OAuth2Service {
 
@@ -38,7 +37,6 @@ public class OAuth2Service {
    * @param googleToken : client 에서 받은 googleToken
    * @return : jwt 토큰을 담은 response
    */
-  @Transactional
   public OAuth2LoginResponseDTO oauth2Login(String googleToken) {
 
     OAuth2UserInfo userInfo = getUserInfoFromGoogle(googleToken);

--- a/src/main/java/dnd/danverse/domain/oauth/service/OAuth2Service.java
+++ b/src/main/java/dnd/danverse/domain/oauth/service/OAuth2Service.java
@@ -11,7 +11,6 @@ import dnd.danverse.domain.member.service.MemberSignUpService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * OAuth2 로그인을 위한 서비스 클래스. 1. google 에서 받은 googleToken 을 통해서 google service 에게 유저 정보를 요청한다. 2.
@@ -51,19 +50,38 @@ public class OAuth2Service {
   }
 
 
-
+  /**
+   * redis 에 refresh token 을 저장한다.
+   * @param email 사용자 email
+   * @param refreshToken refresh token
+   */
   private void saveRefreshTokenToRedis(String email,String refreshToken) {
     redisService.saveRefreshToken(email, refreshToken);
   }
 
+  /**
+   * refresh token 을 생성한다.
+   * @return refresh token
+   */
   private String createRefreshToken() {
     return tokenProvider.createRefreshToken();
   }
 
+  /**
+   * access token 을 생성한다.
+   * @param email 사용자 email
+   * @param role 사용자 권한
+   * @return access token
+   */
   private String createAccessToken(String email, Role role) {
     return tokenProvider.createAccessToken(email, role);
   }
 
+  /**
+   * google service 에게 유저 정보를 요청한다.
+   * @param googleToken client 로 부터 넘어온 googleToken
+   * @return google service 에서 받은 유저 정보
+   */
   private OAuth2UserInfo getUserInfoFromGoogle(String googleToken) {
     String urlInfo = String.format(googleUserInfoUrl, googleToken);
     return httpSocialLoginRequest.getUserInfo(urlInfo);
@@ -71,7 +89,6 @@ public class OAuth2Service {
 
   /**
    * SignUpResult 에서 email 을 추출한다.
-   *
    * @param signUpResult 회원 가입 결과
    * @return email
    */

--- a/src/main/java/dnd/danverse/domain/oauth/service/OAuth2Service.java
+++ b/src/main/java/dnd/danverse/domain/oauth/service/OAuth2Service.java
@@ -1,6 +1,5 @@
 package dnd.danverse.domain.oauth.service;
 
-import dnd.danverse.domain.member.entity.Role;
 import dnd.danverse.domain.member.service.SignUpResult;
 import dnd.danverse.domain.oauth.dto.OAuth2LoginResponseDTO;
 import dnd.danverse.domain.oauth.info.OAuth2UserInfo;
@@ -41,12 +40,11 @@ public class OAuth2Service {
     OAuth2UserInfo userInfo = getUserInfoFromGoogle(googleToken);
     SignUpResult signUpResult = memberSignUpService.signUpOrUpdate(userInfo);
     String email = getEmail(signUpResult);
-    String accessToken = createAccessToken(email, signUpResult.getMember().getRole());
+    String accessToken = createAccessToken(email);
     String refreshToken = createRefreshToken();
     saveRefreshTokenToRedis(email, refreshToken);
 
-    MemberResponse memberResponse = new MemberResponse(signUpResult);
-    return new OAuth2LoginResponseDTO(accessToken, refreshToken, memberResponse);
+    return new OAuth2LoginResponseDTO(accessToken, refreshToken, new MemberResponse(signUpResult));
   }
 
 
@@ -70,11 +68,10 @@ public class OAuth2Service {
   /**
    * access token 을 생성한다.
    * @param email 사용자 email
-   * @param role 사용자 권한
    * @return access token
    */
-  private String createAccessToken(String email, Role role) {
-    return tokenProvider.createAccessToken(email, role);
+  private String createAccessToken(String email) {
+    return tokenProvider.createAccessToken(email);
   }
 
   /**

--- a/src/main/java/dnd/danverse/domain/profile/dto/response/ProfileInfoDto.java
+++ b/src/main/java/dnd/danverse/domain/profile/dto/response/ProfileInfoDto.java
@@ -1,0 +1,93 @@
+package dnd.danverse.domain.profile.dto.response;
+
+import dnd.danverse.domain.profile.entity.Profile;
+import java.time.LocalDate;
+import lombok.Getter;
+
+/**
+ * 프로필 정보를 반환하기 위한 Dto
+ */
+@Getter
+public class ProfileInfoDto {
+
+  /**
+   * 프로필의 고유 ID.
+   */
+  private final Long id;
+  /**
+   * 프로필의 타입. (팀, 개인)
+   */
+  private final String type;
+  /**
+   * 프로필의 이름. (팀명, 개인명)
+   */
+  private final String name;
+  /**
+   * 프로필의 이미지 URL.
+   */
+  private final String imgUrl;
+  /**
+   * 프로필의 작성자의 주 활동 지역
+   */
+  private final String location;
+  /**
+   * 프로필의 작성자의 활동 시작일
+   */
+  private final LocalDate careerStartDay;
+  /**
+   * 프로필의 작성자의 자기소개
+   */
+  private final String description;
+  /**
+   * 프로필의 작성자의 카카오톡 오픈채팅 URL
+   */
+  private final String openChatUrl;
+  /**
+   * 프로필의 작성자의 포트폴리오 URL Dto
+   */
+  private final PortfolioUrl portfolioUrl;
+
+  /**
+   * 프로필의 작성자의 포트폴리오 URL Dto
+   */
+  @Getter
+  public static class PortfolioUrl {
+
+    /**
+     * 프로필의 작성자의 유튜브 URL
+     */
+    private final String youtube;
+    /**
+     * 프로필의 작성자의 인스타그램 URL
+     */
+    private final String instagram;
+    /**
+     * 프로필의 작성자의 트위터 URL
+     */
+    private final String twitter;
+
+    public PortfolioUrl(String youtube, String instagram, String twitter) {
+      this.youtube = youtube;
+      this.instagram = instagram;
+      this.twitter = twitter;
+    }
+  }
+
+  /**
+   * Profile 객체를 이용하여 ProfileInfoDto 를 생성한다.
+   * @param profile 프로필 정보를 담은 객체
+   */
+  public ProfileInfoDto(Profile profile) {
+    this.id = profile.getId();
+    this.type = profile.getProfileType().getType();
+    this.name = profile.getProfileName();
+    this.imgUrl = profile.getProfileImg().getImageUrl();
+    this.location = profile.getLocation();
+    this.careerStartDay = profile.getCareerStartDay();
+    this.description = profile.getDescription();
+    this.openChatUrl = profile.getOpenChatUrl().getOpenChatUrl();
+    this.portfolioUrl = new PortfolioUrl(profile.getPortfolioUrl().getYoutubeUrl(),
+        profile.getPortfolioUrl().getInstagramUrl(), profile.getPortfolioUrl().getTwitterUrl());
+  }
+
+}

--- a/src/main/java/dnd/danverse/domain/profile/dto/response/ProfileInfoDto.java
+++ b/src/main/java/dnd/danverse/domain/profile/dto/response/ProfileInfoDto.java
@@ -1,5 +1,6 @@
 package dnd.danverse.domain.profile.dto.response;
 
+import dnd.danverse.domain.profile.entity.Portfolio;
 import dnd.danverse.domain.profile.entity.Profile;
 import java.time.LocalDate;
 import lombok.Getter;
@@ -66,10 +67,10 @@ public class ProfileInfoDto {
      */
     private final String twitter;
 
-    public PortfolioUrl(String youtube, String instagram, String twitter) {
-      this.youtube = youtube;
-      this.instagram = instagram;
-      this.twitter = twitter;
+    public PortfolioUrl(Portfolio portfolio) {
+      this.youtube = portfolio.getYoutubeUrl();
+      this.instagram = portfolio.getInstagramUrl();
+      this.twitter = portfolio.getTwitterUrl();
     }
   }
 
@@ -86,8 +87,7 @@ public class ProfileInfoDto {
     this.careerStartDay = profile.getCareerStartDay();
     this.description = profile.getDescription();
     this.openChatUrl = profile.getOpenChatUrl().getOpenChatUrl();
-    this.portfolioUrl = new PortfolioUrl(profile.getPortfolioUrl().getYoutubeUrl(),
-        profile.getPortfolioUrl().getInstagramUrl(), profile.getPortfolioUrl().getTwitterUrl());
+    this.portfolioUrl = new PortfolioUrl(profile.getPortfolioUrl());
   }
 
 }

--- a/src/main/java/dnd/danverse/domain/profile/entity/OpenChat.java
+++ b/src/main/java/dnd/danverse/domain/profile/entity/OpenChat.java
@@ -3,12 +3,14 @@ package dnd.danverse.domain.profile.entity;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 /**
  * 카카오 오픈 채팅 Embeddable 객체
  */
 @Embeddable
+@Getter
 @NoArgsConstructor
 public class OpenChat {
 

--- a/src/main/java/dnd/danverse/domain/profile/entity/Portfolio.java
+++ b/src/main/java/dnd/danverse/domain/profile/entity/Portfolio.java
@@ -2,6 +2,7 @@ package dnd.danverse.domain.profile.entity;
 
 
 import javax.persistence.Embeddable;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 /**
@@ -9,6 +10,7 @@ import lombok.NoArgsConstructor;
  * 유튜브, 인스타그램, 트위터 링크를 담는다.
  */
 @Embeddable
+@Getter
 @NoArgsConstructor
 public class Portfolio {
 

--- a/src/main/java/dnd/danverse/global/redis/repository/RefreshTokenRedisRepository.java
+++ b/src/main/java/dnd/danverse/global/redis/repository/RefreshTokenRedisRepository.java
@@ -6,6 +6,9 @@ import java.util.Optional;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
+/**
+ * Refresh Token 을 관리하고 있는 redis 에 접근하기 위한 Repository
+ */
 @Repository
 public interface RefreshTokenRedisRepository extends CrudRepository<RefreshTokenDto, String> {
 

--- a/src/main/java/dnd/danverse/global/redis/service/RedisService.java
+++ b/src/main/java/dnd/danverse/global/redis/service/RedisService.java
@@ -1,8 +1,10 @@
 package dnd.danverse.global.redis.service;
 
+import static dnd.danverse.global.exception.ErrorCode.JWT_REFRESH_TOKEN_EXPIRED;
+
+import dnd.danverse.domain.jwt.exception.JwtException;
 import dnd.danverse.global.redis.dto.RefreshTokenDto;
 import dnd.danverse.global.redis.repository.RefreshTokenRedisRepository;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,7 +35,8 @@ public class RedisService {
    * @param refreshToken : Refresh Token
    * @return : 존재하면 RefreshTokenDto, 존재하지 않으면 Optional.empty()
    */
-  public Optional<RefreshTokenDto> isRefreshTokenExist(String refreshToken) {
-    return refreshTokenRedisRepository.findByRefreshToken(refreshToken);
+  public RefreshTokenDto isRefreshTokenExist(String refreshToken) {
+    return refreshTokenRedisRepository.findByRefreshToken(refreshToken)
+        .orElseThrow(() -> new JwtException(JWT_REFRESH_TOKEN_EXPIRED));
   }
 }

--- a/src/main/java/dnd/danverse/global/security/config/SecurityConfig.java
+++ b/src/main/java/dnd/danverse/global/security/config/SecurityConfig.java
@@ -44,7 +44,7 @@ public class SecurityConfig {
 
 
     http.authorizeRequests()
-        .antMatchers("/api/manager/resource").hasAuthority("ROLE_USER_PROFILE_YES")
+        .antMatchers("/api/manager/resource").hasAuthority("ROLE_MANAGER")
         .anyRequest().permitAll();
 
     http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/dnd/danverse/global/security/config/SecurityConfig.java
+++ b/src/main/java/dnd/danverse/global/security/config/SecurityConfig.java
@@ -46,7 +46,8 @@ public class SecurityConfig {
 
     http.authorizeRequests()
         .antMatchers("/api/manager/resource").hasAuthority("ROLE_MANAGER")
-        .antMatchers(HttpMethod.POST, "/api/v1/events").hasAuthority("ROLE_USER");
+        .antMatchers(HttpMethod.POST, "/api/v1/events").hasAuthority("ROLE_USER")
+        .anyRequest().permitAll();
 
     http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
     http.addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class);

--- a/src/main/java/dnd/danverse/global/util/CookieUtil.java
+++ b/src/main/java/dnd/danverse/global/util/CookieUtil.java
@@ -21,9 +21,7 @@ public class CookieUtil {
    * @param refreshToken 서버에서 생성한 Refresh Token
    * @return Cookie 가 담긴 Header
    */
-  public static HttpHeaders setRefreshCookie(String refreshToken) {
-
-    HttpHeaders headers = new HttpHeaders();
+  public static void setRefreshCookie(HttpHeaders httpHeaders, String refreshToken) {
 
     ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
         .httpOnly(true)
@@ -31,8 +29,6 @@ public class CookieUtil {
         .path("/")
         .build();
 
-    headers.add(HttpHeaders.SET_COOKIE, cookie.toString());
-
-    return headers;
+    httpHeaders.add(HttpHeaders.SET_COOKIE, cookie.toString());
   }
 }

--- a/src/test/java/dnd/danverse/domain/performance/repository/PerformanceRepositoryTest.java
+++ b/src/test/java/dnd/danverse/domain/performance/repository/PerformanceRepositoryTest.java
@@ -213,7 +213,7 @@ class PerformanceRepositoryTest {
             "username" + i,
             "password" + i,
             "imgUrl" + i,
-            Role.USER_PROFILE_NO,
+            Role.ROLE_USER,
             OAuth2Provider.GOOGLE))
         .collect(Collectors.toList());
   }


### PR DESCRIPTION
### ✒️ 관련 이슈번호

- Close #53 

## 🔑 Key Changes

1. 로그인 후, DataBase에 있는 사용자 권한에 따라 다른 권한을 갖는 Access Token을 생성하도록 수정
2. 로그인 후, 반환 되는 데이터에 프로필 데이터 추가 (없으면 null을 반환한다.)
3. 무의식적으로 사용했던 transactional(readOnly=true)를 제거함으로써, transaction이 필요 없는 부분은 적용하지 않도록 수정

## 📢 To Reviewers

- 여전히 코드가 깨끗하지 못 한것 같습니다. 추후 refactoring 시간을 갖고 변경 하도록 하겠습니다.