### PR TITLE
[Refactor] : 이벤트 전체 조회 코드 수정

### DIFF
--- a/src/main/java/dnd/danverse/domain/event/controller/EventController.java
+++ b/src/main/java/dnd/danverse/domain/event/controller/EventController.java
@@ -5,11 +5,11 @@ import dnd.danverse.domain.event.dto.request.EventSavedRequestDto;
 import dnd.danverse.domain.event.dto.response.EventInfoResponse;
 import dnd.danverse.domain.event.dto.response.EventSavedResponseDto;
 import dnd.danverse.domain.event.service.EventService;
-import dnd.danverse.domain.event.service.EventProfileService;
+import dnd.danverse.domain.event.service.EventFilterService;
 import dnd.danverse.domain.jwt.service.SessionUser;
+import dnd.danverse.domain.performance.dto.response.PageDto;
 import dnd.danverse.global.response.DataResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -28,7 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class EventController {
 
-  private final EventProfileService eventProfileService;
+  private final EventFilterService eventFilterService;
   private final EventService eventService;
 
   /**
@@ -39,9 +39,9 @@ public class EventController {
    * @return 페이징 처리된 이벤트 목록 (모집 기간이 지난 이벤트는 제외)
    */
   @GetMapping()
-  public ResponseEntity<DataResponse<Page<EventInfoResponse>>> searchAllEvent(
+  public ResponseEntity<DataResponse<PageDto<EventInfoResponse>>> searchAllEvent(
       EventCondDto eventCondDto, Pageable pageable) {
-    Page<EventInfoResponse> events = eventProfileService.searchAllEventWithCond(
+    PageDto<EventInfoResponse> events = eventFilterService.searchAllEventWithCond(
         eventCondDto, pageable);
     return new ResponseEntity<>(DataResponse.of(HttpStatus.OK, "이벤트 조회 성공", events), HttpStatus.OK);
   }

--- a/src/main/java/dnd/danverse/domain/event/dto/response/EventInfoResponse.java
+++ b/src/main/java/dnd/danverse/domain/event/dto/response/EventInfoResponse.java
@@ -25,6 +25,7 @@ public class EventInfoResponse {
   // 이벤트 주최자
   @Getter
   static class ProfileSimpleInfo {
+
     private final Long id;
     private final String name;
     private final String imgUrl;
@@ -38,14 +39,16 @@ public class EventInfoResponse {
   }
 
   @QueryProjection
-   public EventInfoResponse(Long eventId, String title, String location, EventType type, String eventImg, LocalDateTime eventDeadline, LocalDateTime eventCreatedAt, Long profileId, String profileName, String profileImg) {
-      this.id = eventId;
-      this.title = title;
-      this.location = location;
-      this.type = type;
-      this.imgUrl = eventImg;
-      this.deadline = eventDeadline;
-      this.createdAt = eventCreatedAt;
-      this.profile = new ProfileSimpleInfo(profileId, profileName, profileImg);
-    }
+  public EventInfoResponse(Long eventId, String title, String location, EventType type,
+      String eventImg, LocalDateTime eventDeadline, LocalDateTime eventCreatedAt, Long profileId,
+      String profileName, String profileImg) {
+    this.id = eventId;
+    this.title = title;
+    this.location = location;
+    this.type = type;
+    this.imgUrl = eventImg;
+    this.deadline = eventDeadline;
+    this.createdAt = eventCreatedAt;
+    this.profile = new ProfileSimpleInfo(profileId, profileName, profileImg);
+  }
 }

--- a/src/main/java/dnd/danverse/domain/event/dto/response/EventInfoResponse.java
+++ b/src/main/java/dnd/danverse/domain/event/dto/response/EventInfoResponse.java
@@ -19,6 +19,7 @@ public class EventInfoResponse {
   private final EventType type;
   private final String eventImg;
   private final LocalDateTime eventDeadLine;
+  private final LocalDateTime eventCreatedAt;
 
   // 이벤트 주최자
   private final Long profileId;
@@ -26,15 +27,16 @@ public class EventInfoResponse {
   private final String profileImg;
 
   @QueryProjection
-  public EventInfoResponse(Long eventId, String title, String location, EventType type, String eventImg, LocalDateTime eventDeadLine, Long profileId, String profileName, String profileImg) {
-    this.eventId = eventId;
-    this.title = title;
-    this.location = location;
-    this.type = type;
-    this.eventImg = eventImg;
-    this.eventDeadLine = eventDeadLine;
-    this.profileId = profileId;
-    this.profileName = profileName;
-    this.profileImg = profileImg;
-  }
+   public EventInfoResponse(Long eventId, String title, String location, EventType type, String eventImg, LocalDateTime eventDeadLine, LocalDateTime eventCreatedAt, Long profileId, String profileName, String profileImg) {
+      this.eventId = eventId;
+      this.title = title;
+      this.location = location;
+      this.type = type;
+      this.eventImg = eventImg;
+      this.eventDeadLine = eventDeadLine;
+      this.eventCreatedAt = eventCreatedAt;
+      this.profileId = profileId;
+      this.profileName = profileName;
+      this.profileImg = profileImg;
+    }
 }

--- a/src/main/java/dnd/danverse/domain/event/dto/response/EventInfoResponse.java
+++ b/src/main/java/dnd/danverse/domain/event/dto/response/EventInfoResponse.java
@@ -13,30 +13,39 @@ import lombok.Getter;
 public class EventInfoResponse {
 
   // 이벤트
-  private final Long eventId;
+  private final Long id;
   private final String title;
   private final String location;
   private final EventType type;
-  private final String eventImg;
-  private final LocalDateTime eventDeadLine;
-  private final LocalDateTime eventCreatedAt;
+  private final String imgUrl;
+  private final LocalDateTime deadline;
+  private final LocalDateTime createdAt;
+  private final ProfileSimpleInfo profile;
 
   // 이벤트 주최자
-  private final Long profileId;
-  private final String profileName;
-  private final String profileImg;
+  @Getter
+  static class ProfileSimpleInfo {
+    private final Long id;
+    private final String name;
+    private final String imgUrl;
+
+    @QueryProjection
+    public ProfileSimpleInfo(Long id, String name, String imgUrl) {
+      this.id = id;
+      this.name = name;
+      this.imgUrl = imgUrl;
+    }
+  }
 
   @QueryProjection
-   public EventInfoResponse(Long eventId, String title, String location, EventType type, String eventImg, LocalDateTime eventDeadLine, LocalDateTime eventCreatedAt, Long profileId, String profileName, String profileImg) {
-      this.eventId = eventId;
+   public EventInfoResponse(Long eventId, String title, String location, EventType type, String eventImg, LocalDateTime eventDeadline, LocalDateTime eventCreatedAt, Long profileId, String profileName, String profileImg) {
+      this.id = eventId;
       this.title = title;
       this.location = location;
       this.type = type;
-      this.eventImg = eventImg;
-      this.eventDeadLine = eventDeadLine;
-      this.eventCreatedAt = eventCreatedAt;
-      this.profileId = profileId;
-      this.profileName = profileName;
-      this.profileImg = profileImg;
+      this.imgUrl = eventImg;
+      this.deadline = eventDeadline;
+      this.createdAt = eventCreatedAt;
+      this.profile = new ProfileSimpleInfo(profileId, profileName, profileImg);
     }
 }

--- a/src/main/java/dnd/danverse/domain/event/repository/EventRepositoryImpl.java
+++ b/src/main/java/dnd/danverse/domain/event/repository/EventRepositoryImpl.java
@@ -40,9 +40,6 @@ public class EventRepositoryImpl implements EventFilterCustom {
    */
   public Page<EventInfoResponse> searchAllEventWithCond(EventCondDto eventCond, Pageable pageable) {
 
-    // 현재 시간 이후로 모집 기간이 지난 이벤트는 제외하기 위해
-    LocalDateTime now = LocalDateTime.now();
-
     // dto 를 통해서 이벤트 및 프로필 정보만 조회
     List<EventInfoResponse> eventContent = queryFactory
         .select(new QEventInfoResponse(
@@ -60,8 +57,8 @@ public class EventRepositoryImpl implements EventFilterCustom {
         .join(event.profile, profile)
         .where(
             locationEq(eventCond.getLocation()),
-            eventTypeEq(EventType.of(eventCond.getType())),
-            eventAfterNow(now))
+            eventTypeEq(EventType.of(eventCond.getType()))
+        )
         .offset(pageable.getOffset())
         .limit(pageable.getPageSize())
         .fetch();
@@ -70,14 +67,7 @@ public class EventRepositoryImpl implements EventFilterCustom {
     return PageableExecutionUtils.getPage(eventContent, pageable, () -> getTotalCount(eventCond));
   }
 
-  /**
-   * 이벤트 모집 기간이 현재 시간 이후인 이벤트만 조회
-   * @param now 현재 시간
-   * @return BooleanExpression 을 반환하여 동적 쿼리를 만든다.
-   */
-  private BooleanExpression eventAfterNow(LocalDateTime now) {
-    return event.deadline.after(now);
-  }
+
 
   /**
    * 전체 이벤트 갯수를 조회한다.

--- a/src/main/java/dnd/danverse/domain/event/repository/EventRepositoryImpl.java
+++ b/src/main/java/dnd/danverse/domain/event/repository/EventRepositoryImpl.java
@@ -12,7 +12,6 @@ import dnd.danverse.domain.event.dto.response.EventInfoResponse;
 import dnd.danverse.domain.event.dto.response.QEventInfoResponse;
 import dnd.danverse.domain.event.entitiy.Event;
 import dnd.danverse.domain.event.entitiy.EventType;
-import java.time.LocalDateTime;
 import java.util.List;
 import javax.persistence.EntityManager;
 import org.springframework.data.domain.Page;
@@ -49,6 +48,7 @@ public class EventRepositoryImpl implements EventFilterCustom {
             event.eventType,
             event.eventImg.imageUrl,
             event.deadline,
+            event.createdAt,
             profile.id,
             profile.profileName,
             profile.profileImg.imageUrl
@@ -59,6 +59,7 @@ public class EventRepositoryImpl implements EventFilterCustom {
             locationEq(eventCond.getLocation()),
             eventTypeEq(EventType.of(eventCond.getType()))
         )
+        .orderBy(event.createdAt.desc())
         .offset(pageable.getOffset())
         .limit(pageable.getPageSize())
         .fetch();

--- a/src/main/java/dnd/danverse/domain/event/service/EventFilterService.java
+++ b/src/main/java/dnd/danverse/domain/event/service/EventFilterService.java
@@ -3,7 +3,7 @@ package dnd.danverse.domain.event.service;
 import dnd.danverse.domain.event.dto.request.EventCondDto;
 import dnd.danverse.domain.event.dto.response.EventInfoResponse;
 import dnd.danverse.domain.event.repository.EventRepository;
-import dnd.danverse.domain.profile.ProfileRepository;
+import dnd.danverse.domain.performance.dto.response.PageDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -16,18 +16,21 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class EventProfileService {
+public class EventFilterService {
 
-  private final ProfileRepository profileRepository;
   private final EventRepository eventRepository;
 
   /**
    * 이벤트 필터링과, 페이징을 적용한 이벤트 조회.
+   *
    * @param eventCondDto 이벤트 필터링 조건
-   * @param pageable 페이징 조건
+   * @param pageable     페이징 조건
    * @return 페이징 처리된 이벤트 목록 (모집 기간이 지난 이벤트는 제외)
    */
-  public Page<EventInfoResponse> searchAllEventWithCond(EventCondDto eventCondDto, Pageable pageable) {
-    return eventRepository.searchAllEventWithCond(eventCondDto, pageable);
+  public PageDto<EventInfoResponse> searchAllEventWithCond(EventCondDto eventCondDto,
+      Pageable pageable) {
+    Page<EventInfoResponse> eventInfoResponses = eventRepository.searchAllEventWithCond(
+        eventCondDto, pageable);
+    return new PageDto<>(eventInfoResponses);
   }
 }


### PR DESCRIPTION
### ✒️ 관련 이슈번호

- Close #57 

## 🔑 Key Changes

1. 이벤트 전체 조회 시, 마감 기한 지난 것도 우선적으로 보여주기
2. 이벤트 전체 조회 시, 제일 최근에 올라온 게시글이 위에 위치하도록 정렬 조건 추가
3. 이벤트 전체 조회 시, 응답 값 변수명을 명세서에 맞게 변경하기 (응답 값을 성격이 맞는 객체끼리 묶어주기)
4. 페이징 응답 시, 필요한 데이터만 응답 하도록 수정 (PageDto로 활용)
5. EventProfileService를 EventFilterService 로써 네이밍 수정

## 📢 To Reviewers

- None