### PR TITLE
[Feat] : 이벤트 신청 기능 추가

### DIFF
--- a/src/main/java/dnd/danverse/domain/event/entitiy/Event.java
+++ b/src/main/java/dnd/danverse/domain/event/entitiy/Event.java
@@ -1,8 +1,11 @@
 package dnd.danverse.domain.event.entitiy;
 
+import static dnd.danverse.global.exception.ErrorCode.EVENT_OVER_DEADLINE;
+
 import dnd.danverse.domain.common.BaseTimeEntity;
 import dnd.danverse.domain.common.Image;
 import dnd.danverse.domain.common.TeamType;
+import dnd.danverse.domain.event.exception.EventNotAvailableException;
 import dnd.danverse.domain.profile.entity.Profile;
 import java.time.LocalDateTime;
 import javax.persistence.Column;
@@ -108,4 +111,20 @@ public class Event extends BaseTimeEntity {
   private Image eventImg;
 
 
+  /**
+   * 요청한 시간이 마감 기한보다 늦은지 확인한다.
+   * @return 마감 기한이 지났으면 true, 아니면 false
+   */
+  public boolean overDeadline() {
+    return LocalDateTime.now().isAfter(this.deadline);
+  }
+
+  /**
+   * 이벤트 모집 기간이 지났는지 확인한다.
+   */
+  public void checkIfOverDeadline() {
+    if (overDeadline()) {
+      throw new EventNotAvailableException(EVENT_OVER_DEADLINE);
+    }
+  }
 }

--- a/src/main/java/dnd/danverse/domain/event/exception/EventNotAvailableException.java
+++ b/src/main/java/dnd/danverse/domain/event/exception/EventNotAvailableException.java
@@ -1,0 +1,14 @@
+package dnd.danverse.domain.event.exception;
+
+import dnd.danverse.global.exception.BusinessException;
+import dnd.danverse.global.exception.ErrorCode;
+
+/**
+ * 이벤트 신청이 불가능한 경우 발생하는 예외
+ */
+public class EventNotAvailableException extends BusinessException {
+
+  public EventNotAvailableException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+}

--- a/src/main/java/dnd/danverse/domain/event/exception/EventNotFoundException.java
+++ b/src/main/java/dnd/danverse/domain/event/exception/EventNotFoundException.java
@@ -1,0 +1,14 @@
+package dnd.danverse.domain.event.exception;
+
+import dnd.danverse.global.exception.BusinessException;
+import dnd.danverse.global.exception.ErrorCode;
+
+/**
+ * 이벤트를 찾지 못 했을 경우 발생하는 예외
+ */
+public class EventNotFoundException extends BusinessException {
+
+  public EventNotFoundException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+}

--- a/src/main/java/dnd/danverse/domain/event/service/EventPureService.java
+++ b/src/main/java/dnd/danverse/domain/event/service/EventPureService.java
@@ -1,0 +1,35 @@
+package dnd.danverse.domain.event.service;
+
+import static dnd.danverse.global.exception.ErrorCode.EVENT_NOT_FOUND;
+
+import dnd.danverse.domain.event.entitiy.Event;
+import dnd.danverse.domain.event.exception.EventNotFoundException;
+import dnd.danverse.domain.event.repository.EventRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Event Entity 에 대한 순수 Service
+ */
+@Service
+@RequiredArgsConstructor
+public class EventPureService {
+
+  private final EventRepository eventRepository;
+
+  /**
+   * 이벤트 신청 가능 여부 확인
+   * 이벤트가 존재하는지 확인하고, 신청 기간이 지났는지 확인한다.
+   * @param eventId 이벤트 ID
+   * @return 이벤트
+   */
+  @Transactional(readOnly = true)
+  public Event checkAvailable(Long eventId) {
+    Event event = eventRepository.findById(eventId).orElseThrow(
+        () -> new EventNotFoundException(EVENT_NOT_FOUND));
+
+    event.checkIfOverDeadline();
+    return event;
+  }
+}

--- a/src/main/java/dnd/danverse/domain/event/service/EventService.java
+++ b/src/main/java/dnd/danverse/domain/event/service/EventService.java
@@ -5,7 +5,7 @@ import static dnd.danverse.global.exception.ErrorCode.PROFILE_NOT_FOUND;
 import dnd.danverse.domain.event.dto.request.EventSavedRequestDto;
 import dnd.danverse.domain.event.dto.response.EventSavedResponseDto;
 import dnd.danverse.domain.event.entitiy.Event;
-import dnd.danverse.domain.event.exception.NoProfileException;
+import dnd.danverse.domain.profile.exception.NoProfileException;
 import dnd.danverse.domain.event.repository.EventRepository;
 import dnd.danverse.domain.profile.ProfileRepository;
 import dnd.danverse.domain.profile.dto.response.ProfileDto;

--- a/src/main/java/dnd/danverse/domain/matching/controller/EventMatchController.java
+++ b/src/main/java/dnd/danverse/domain/matching/controller/EventMatchController.java
@@ -1,0 +1,40 @@
+package dnd.danverse.domain.matching.controller;
+
+import dnd.danverse.domain.jwt.service.SessionUser;
+import dnd.danverse.domain.matching.dto.request.EventIdRequestDto;
+import dnd.danverse.domain.matching.service.EventMatchComplexService;
+import dnd.danverse.global.response.MessageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+/**
+ * 이벤트 매칭을 위한 컨트롤러.
+ */
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/events")
+public class EventMatchController {
+
+  private final EventMatchComplexService eventMatchComplexService;
+
+  /**
+   * 이벤트 매칭을 진행한다.
+   * @param requestDto 신청하고자 하는 이벤트 ID가 담긴 DTO
+   * @param sessionUser 현재 로그인한 유저의 정보
+   * @return 성공 메시지
+   */
+  @PostMapping("/match")
+  public ResponseEntity<MessageResponse> matchEvent(@RequestBody EventIdRequestDto requestDto, @AuthenticationPrincipal
+  SessionUser sessionUser) {
+    eventMatchComplexService.matchEvent(requestDto, sessionUser.getId());
+    return new ResponseEntity<>(MessageResponse.of(HttpStatus.OK, "이벤트 매칭 성공"), HttpStatus.OK);
+  }
+
+
+}

--- a/src/main/java/dnd/danverse/domain/matching/dto/request/EventIdRequestDto.java
+++ b/src/main/java/dnd/danverse/domain/matching/dto/request/EventIdRequestDto.java
@@ -1,0 +1,18 @@
+package dnd.danverse.domain.matching.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 이벤트 id를 전달하기 위한 DTO.
+ */
+@Getter
+@NoArgsConstructor
+public class EventIdRequestDto {
+
+  /**
+   * 이벤트 id
+   */
+  private Long eventId;
+
+}

--- a/src/main/java/dnd/danverse/domain/matching/entity/EventMatch.java
+++ b/src/main/java/dnd/danverse/domain/matching/entity/EventMatch.java
@@ -1,6 +1,7 @@
 package dnd.danverse.domain.matching.entity;
 
 import dnd.danverse.domain.common.BaseTimeEntity;
+import dnd.danverse.domain.event.entitiy.Event;
 import dnd.danverse.domain.profile.entity.Profile;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -12,6 +13,7 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.PrePersist;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.GenericGenerator;
@@ -43,11 +45,11 @@ public class EventMatch extends BaseTimeEntity {
   private Long id;
 
   /**
-   * 이벤트 매칭 주최자
+   * 이벤트 매칭 이벤트
    */
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "profile_host_id", nullable = false, foreignKey = @ForeignKey(name = "FK_EVENT_MATCH_PROFILE_HOST"))
-  private Profile profileHost;
+  @JoinColumn(name = "event_id", nullable = false, foreignKey = @ForeignKey(name = "FK_EVENT_MATCH_EVENT"))
+  private Event event;
 
   /**
    * 이벤트 매칭 지원자
@@ -73,5 +75,15 @@ public class EventMatch extends BaseTimeEntity {
   }
 
 
+  /**
+   * 이벤트 매칭 생성자
+   * @param event 이벤트
+   * @param profileGuest 지원자
+   */
+  @Builder
+  public EventMatch(Event event, Profile profileGuest) {
+    this.event = event;
+    this.profileGuest = profileGuest;
+  }
 
 }

--- a/src/main/java/dnd/danverse/domain/matching/repository/EventMatchRepository.java
+++ b/src/main/java/dnd/danverse/domain/matching/repository/EventMatchRepository.java
@@ -1,0 +1,10 @@
+package dnd.danverse.domain.matching.repository;
+
+import dnd.danverse.domain.matching.entity.EventMatch;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EventMatchRepository extends JpaRepository<EventMatch, Long> {
+
+}

--- a/src/main/java/dnd/danverse/domain/matching/service/EventMatchComplexService.java
+++ b/src/main/java/dnd/danverse/domain/matching/service/EventMatchComplexService.java
@@ -1,0 +1,44 @@
+package dnd.danverse.domain.matching.service;
+
+import dnd.danverse.domain.event.entitiy.Event;
+import dnd.danverse.domain.event.service.EventPureService;
+import dnd.danverse.domain.matching.dto.request.EventIdRequestDto;
+import dnd.danverse.domain.profile.entity.Profile;
+import dnd.danverse.domain.profile.service.ProfilePureService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * Event Match 를 위한 복합 Service
+ */
+@Service
+@RequiredArgsConstructor
+public class EventMatchComplexService {
+
+  private final EventMatchPureService eventMatchPureService;
+  private final ProfilePureService profilePureService;
+  private final EventPureService eventPureService;
+
+  /**
+   * 이벤트 신청 전 복합적인 검증을 진행한다.
+   * 1. 신청자의 프로필이 존재하는지 확인한다.
+   * 2. 신청 가능한 이벤트인지 확인한다. (존재하는지, 신청 기간이 지났는지)
+   * 3. 신청자의 모집 유형이 이벤트의 모집 유형과 일치하는지 확인한다.
+   * 4. 모든 검증이 완료되면, 이벤트 신청을 진행한다.
+   * @param requestDto 이벤트 신청을 위한 요청 DTO
+   * @param memberId 신청자의 고유 DB ID
+   */
+  public void matchEvent(EventIdRequestDto requestDto, Long memberId) {
+    // id 에 해당하는 Profile 을 가지고 있는지 확인한다. 없으면 권한이 없다는 Exception 을 던진다.
+    Profile applier = profilePureService.retrieveProfile(memberId);
+
+    // requestDto 에 담긴 eventID를 통해서 신청 가능한 이벤트인지 확인한다. 아니면 Exception 을 던진다.
+    Event targetEvent = eventPureService.checkAvailable(requestDto.getEventId());
+
+    // 모집 유형이 일치한지 확인한다. 아니면 Exception 을 던진다.
+    applier.checkMatchType(targetEvent.getRecruitType());
+
+    // profile 도 가지고 있고, 신청 가능한 이벤트라면, 신청을 진행한다.
+    eventMatchPureService.matchEvent(targetEvent, applier);
+  }
+}

--- a/src/main/java/dnd/danverse/domain/matching/service/EventMatchPureService.java
+++ b/src/main/java/dnd/danverse/domain/matching/service/EventMatchPureService.java
@@ -1,0 +1,35 @@
+package dnd.danverse.domain.matching.service;
+
+import dnd.danverse.domain.event.entitiy.Event;
+import dnd.danverse.domain.matching.entity.EventMatch;
+import dnd.danverse.domain.matching.repository.EventMatchRepository;
+import dnd.danverse.domain.profile.entity.Profile;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Event Match Entity 에 대한 순수 Service
+ */
+@Service
+@RequiredArgsConstructor
+public class EventMatchPureService {
+
+  private final EventMatchRepository eventMatchRepository;
+
+
+  /**
+   * 이벤트 신청
+   * @param event 신청하고자 하는 이벤트
+   * @param profile 지원하고자 하는 사람의 프로필
+   */
+  @Transactional
+  public void matchEvent(Event event, Profile profile) {
+    EventMatch eventMatch = EventMatch.builder()
+        .event(event)
+        .profileGuest(profile)
+        .build();
+
+    eventMatchRepository.save(eventMatch);
+  }
+}

--- a/src/main/java/dnd/danverse/domain/profile/entity/Profile.java
+++ b/src/main/java/dnd/danverse/domain/profile/entity/Profile.java
@@ -1,8 +1,11 @@
 package dnd.danverse.domain.profile.entity;
 
+import static dnd.danverse.global.exception.ErrorCode.EVENT_TYPE_NOT_MATCH;
+
 import dnd.danverse.domain.common.BaseTimeEntity;
 import dnd.danverse.domain.common.Image;
 import dnd.danverse.domain.common.TeamType;
+import dnd.danverse.domain.event.exception.EventNotAvailableException;
 import dnd.danverse.domain.member.entity.Member;
 import dnd.danverse.domain.profilegenre.entity.ProfileGenre;
 import java.time.LocalDate;
@@ -136,5 +139,13 @@ public class Profile extends BaseTimeEntity {
   }
 
 
-
+  /**
+   * 프로필의 팀 타입과 모집 타입이 일치하는지 확인한다.
+   * @param recruitType 모집 타입
+   */
+  public void checkMatchType(TeamType recruitType) {
+    if (this.profileType != recruitType) {
+      throw new EventNotAvailableException(EVENT_TYPE_NOT_MATCH);
+    }
+  }
 }

--- a/src/main/java/dnd/danverse/domain/profile/exception/NoProfileException.java
+++ b/src/main/java/dnd/danverse/domain/profile/exception/NoProfileException.java
@@ -1,10 +1,10 @@
-package dnd.danverse.domain.event.exception;
+package dnd.danverse.domain.profile.exception;
 
 import dnd.danverse.global.exception.BusinessException;
 import dnd.danverse.global.exception.ErrorCode;
 
 /**
- * 이벤트 글을 작성할 때 프로필 미등록이면 발생하는 예외.
+ * 프로필 미등록이면 발생하는 예외.
  */
 public class NoProfileException extends BusinessException {
   public NoProfileException(ErrorCode errorCode) {

--- a/src/main/java/dnd/danverse/domain/profile/service/ProfilePureService.java
+++ b/src/main/java/dnd/danverse/domain/profile/service/ProfilePureService.java
@@ -1,0 +1,31 @@
+package dnd.danverse.domain.profile.service;
+
+import static dnd.danverse.global.exception.ErrorCode.PROFILE_NOT_FOUND;
+
+import dnd.danverse.domain.profile.exception.NoProfileException;
+import dnd.danverse.domain.profile.ProfileRepository;
+import dnd.danverse.domain.profile.entity.Profile;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Profile Entity 에 대한 순수 Service
+ */
+@Service
+@RequiredArgsConstructor
+public class ProfilePureService {
+
+  private final ProfileRepository profileRepository;
+
+  /**
+   * 프로필 조회
+   * @param memberId 사용자 (member 고유 DB ID)
+   * @return 프로필
+   */
+  @Transactional(readOnly = true)
+  public Profile retrieveProfile(Long memberId) {
+    return profileRepository.findByMember(memberId)
+        .orElseThrow(() -> new NoProfileException(PROFILE_NOT_FOUND));
+  }
+}

--- a/src/main/java/dnd/danverse/global/exception/ErrorCode.java
+++ b/src/main/java/dnd/danverse/global/exception/ErrorCode.java
@@ -18,11 +18,19 @@ public enum ErrorCode {
   HANDLE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "C005", "접근이 거부 되었습니다."),
 
   // Depend on Entity (도메인에 따라서 달라지는 경우)
+  // 이벤트
   EMAIL_DUPLICATION(HttpStatus.BAD_REQUEST, "E001", "이메일 중복 입니다."),
-  LOGIN_INPUT_INVALID(HttpStatus.BAD_REQUEST, "L002", "로그인 정보가 올바르지 않습니다."),
+  EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "E002", "존재하지 않는 이벤트입니다."),
+  EVENT_OVER_DEADLINE(HttpStatus.BAD_REQUEST, "E003", "신청 기간이 지났습니다."),
+  EVENT_TYPE_NOT_MATCH(HttpStatus.BAD_REQUEST, "E004", "모집 유형이 일치하지 않습니다."),
 
-  MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "M003", "존재하지 않는 회원입니다."),
+  // 회원 member
+  MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "M001", "존재하지 않는 회원입니다."),
+
+  // 프로필
   PROFILE_NOT_FOUND(HttpStatus.BAD_REQUEST, "P001", "프로필 등록이 필요한 서비스입니다."),
+
+  // Enum Type
   TYPE_NOT_FOUND(HttpStatus.BAD_REQUEST, "T001", "해당 타입은 존재하지 않습니다."),
 
 

--- a/src/main/java/dnd/danverse/global/security/config/SecurityConfig.java
+++ b/src/main/java/dnd/danverse/global/security/config/SecurityConfig.java
@@ -46,7 +46,7 @@ public class SecurityConfig {
 
     http.authorizeRequests()
         .antMatchers("/api/manager/resource").hasAuthority("ROLE_MANAGER")
-        .antMatchers(HttpMethod.POST, "/api/v1/events").hasAuthority("ROLE_USER")
+        .antMatchers(HttpMethod.POST, "/api/v1/events","/api/v1/events/match").hasAuthority("ROLE_USER")
         .anyRequest().permitAll();
 
     http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);


### PR DESCRIPTION
### ✒️ 관련 이슈번호

- Close #59 

## 🔑 Key Changes

1. 복합 Service 와 순수 Service 의 역할을 분리하여 코드 작성
  - 복합 Service는 디자인 패턴의 Facade 패턴처럼 하위 순수 Service에게 메시지를 주로 보낸다.
  - 하위 Service는 메시지를 수신하고, 내부적으로 Exception 처리를 한다.
  - 하위 Service는 주도적으로 도메인 객체에게 메시지를 보내며, 필요 시 도메인 객체가 직접 Exception을 반환한다.
2. 이벤트 신청 기능 추가
3. 발생 가능한 Exception 정의

## 📢 To Reviewers

- None