### PR TITLE
[Feat] : 공연 정보글 상세조회 기능 구현

### DIFF
--- a/src/main/java/dnd/danverse/domain/performance/controller/PerformanceController.java
+++ b/src/main/java/dnd/danverse/domain/performance/controller/PerformanceController.java
@@ -3,16 +3,21 @@ package dnd.danverse.domain.performance.controller;
 import dnd.danverse.domain.performance.dto.request.PerformCondDto;
 import dnd.danverse.domain.performance.dto.response.ImminentPerformsDto;
 import dnd.danverse.domain.performance.dto.response.PageDto;
+import dnd.danverse.domain.performance.dto.response.PerformDetailResponse;
 import dnd.danverse.domain.performance.dto.response.PerformInfoResponse;
 import dnd.danverse.domain.performance.service.PerformFilterService;
+import dnd.danverse.domain.performance.service.PerformSearchComplexService;
 import dnd.danverse.domain.performance.service.PerformancePureService;
 import dnd.danverse.global.response.DataResponse;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiOperation;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import springfox.documentation.annotations.ApiIgnore;
@@ -28,6 +33,7 @@ public class PerformanceController {
 
   private final PerformancePureService performancePureService;
   private final PerformFilterService performFilterService;
+  private final PerformSearchComplexService performSearchComplexService;
 
   /**
    * 공연이 임박한 공연을 조회할 수 있다. 오늘 날짜 기준으로, 최근 공연 4개를 조회할 수 있다.
@@ -43,6 +49,7 @@ public class PerformanceController {
 
   /**
    * 공연 필터링과, 페이징을 적용한 공연 조회.
+   *
    * @param performCondDto 공연 필터링 조건
    * @param pageable 페이징 조건
    * @return 페이징 처리된 공연 목록
@@ -57,6 +64,15 @@ public class PerformanceController {
     return new ResponseEntity<>(
         DataResponse.of(HttpStatus.OK, "공연 조회 성공", performInfoResponsePageDto), HttpStatus.OK);
   }
+
+  @GetMapping("/{performId}")
+  @ApiOperation(value = "공연 글 상세조회", notes = "공연 정보 글을 상세 조회할 수 있다.")
+  @ApiImplicitParam(name = "performId", value = "공연 고유 ID", required = true)
+  public ResponseEntity<DataResponse<PerformDetailResponse>> getDetailPerform(@PathVariable("performId") Long performId) {
+    PerformDetailResponse response = performSearchComplexService.getDetailPerform(performId);
+    return new ResponseEntity<>(DataResponse.of(HttpStatus.OK, "공연 상세조회 성공", response), HttpStatus.OK);
+  }
+
 
 
 }

--- a/src/main/java/dnd/danverse/domain/performance/dto/response/PerformDetailResponse.java
+++ b/src/main/java/dnd/danverse/domain/performance/dto/response/PerformDetailResponse.java
@@ -1,0 +1,94 @@
+package dnd.danverse.domain.performance.dto.response;
+
+import dnd.danverse.domain.performance.entity.Performance;
+import dnd.danverse.domain.profile.dto.response.ProfileSimpleDto;
+import io.swagger.annotations.ApiModelProperty;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 공연 상세조회 정보를 담은 Dto.
+ */
+@Getter
+public class PerformDetailResponse {
+
+  /**
+   * 공연 정보글의 고유 Id.
+   */
+  @ApiModelProperty(value = "공연 고유 ID")
+  private final Long id;
+
+  /**
+   * 공연 정보글의 제목.
+   */
+  @ApiModelProperty(value = "공연 제목")
+  private final String title;
+
+  /**
+   * 공연 정보글에 담기는 이미지 url.
+   */
+  @ApiModelProperty(value = "공연의 imgUrl")
+  private final String imgUrl;
+
+  /**
+   * 공연의 시작 날짜.
+   */
+  @ApiModelProperty(value = "공연 시작 날짜")
+  private final LocalDate startDate;
+
+  /**
+   * 공연 시작 시간.
+   */
+  @ApiModelProperty(value = "공연 시작 시간")
+  private final LocalDateTime startTime;
+
+  /**
+   * 공연 진행 지역.
+   */
+  @ApiModelProperty(value = "공연 지역")
+  private final String location;
+
+  /**
+   * 공연 장르.
+   */
+  @ApiModelProperty(value = "공연 장르")
+  private final List<String> genres;
+
+  /**
+   * 공연에 대한 상세설명.
+   */
+  @ApiModelProperty(value = "공연 상세설명")
+  private final String description;
+
+  /**
+   * 공연 진행 장소.
+   */
+  @ApiModelProperty(value = "공연 장소")
+  private final String address;
+
+  /**
+   * 공연 주최자의 프로필.
+   */
+  @ApiModelProperty(value = "공연 주최자의 프로필 정보를 담은 dto")
+  private final ProfileSimpleDto profile;
+
+  @Builder
+  public PerformDetailResponse(Performance perform) {
+    this.id = perform.getId();
+    this.title = perform.getTitle();
+    this.imgUrl = perform.getPerformanceImg().getImageUrl();
+    this.startDate = perform.getStartDate();
+    this.startTime = perform.getStartTime();
+    this.location = perform.getLocation();
+    this.genres = perform.getPerformGenres();
+    this.description = perform.getDescription();
+    this.address = perform.getAddress();
+    this.profile = new ProfileSimpleDto(perform.getProfileHost());
+  }
+
+
+
+}

--- a/src/main/java/dnd/danverse/domain/performance/exception/PerformanceNotFoundException.java
+++ b/src/main/java/dnd/danverse/domain/performance/exception/PerformanceNotFoundException.java
@@ -1,0 +1,13 @@
+package dnd.danverse.domain.performance.exception;
+
+import dnd.danverse.global.exception.BusinessException;
+import dnd.danverse.global.exception.ErrorCode;
+
+/**
+ * 조회하고자 하는 공연 정보글이 없을 때 예외처리.
+ */
+public class PerformanceNotFoundException extends BusinessException {
+  public PerformanceNotFoundException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+}

--- a/src/main/java/dnd/danverse/domain/performance/repository/PerformanceRepository.java
+++ b/src/main/java/dnd/danverse/domain/performance/repository/PerformanceRepository.java
@@ -3,6 +3,7 @@ package dnd.danverse.domain.performance.repository;
 import dnd.danverse.domain.performance.entity.Performance;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -16,4 +17,13 @@ public interface PerformanceRepository extends JpaRepository<Performance, Long>,
 
   @Query("select p from Performance p where p.startDate >= :now order by p.startDate asc")
   List<Performance> findImminentPerforms(@Param("now") LocalDate now);
+
+  /**
+   * 공연 주최자의 프로필과 공연을 fetch join하여 반환.
+   *
+   * @param performId 조회하고자 하는 공연 정보글의 Id.
+   * @return Performance 를 반환함. 만약 없다면 PerformanceNotFoundException 반환.
+   */
+  @Query("select p from Performance p join fetch p.profileHost where p.id = :performId")
+  Optional<Performance> findPerformanceWithProfile(@Param("performId") Long performId);
 }

--- a/src/main/java/dnd/danverse/domain/performance/service/PerformSearchComplexService.java
+++ b/src/main/java/dnd/danverse/domain/performance/service/PerformSearchComplexService.java
@@ -5,7 +5,9 @@ import dnd.danverse.domain.performance.entity.Performance;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-
+/**
+ * 공연 조회 복합 서비스.
+ */
 @Service
 @RequiredArgsConstructor
 public class PerformSearchComplexService {

--- a/src/main/java/dnd/danverse/domain/performance/service/PerformSearchComplexService.java
+++ b/src/main/java/dnd/danverse/domain/performance/service/PerformSearchComplexService.java
@@ -1,0 +1,24 @@
+package dnd.danverse.domain.performance.service;
+
+import dnd.danverse.domain.performance.dto.response.PerformDetailResponse;
+import dnd.danverse.domain.performance.entity.Performance;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+
+@Service
+@RequiredArgsConstructor
+public class PerformSearchComplexService {
+  private final PerformancePureService performancePureService;
+
+  /**
+   * 공연 정보 상세 조회.
+   *
+   * @param performId 조회하고자 하는 performId.
+   * @return 공연 정보와 프로필 정보를 담은 responseDto 반환.
+   */
+  public PerformDetailResponse getDetailPerform(Long performId) {
+    Performance perform = performancePureService.getPerformanceDetail(performId);
+    return new PerformDetailResponse(perform);
+  }
+}

--- a/src/main/java/dnd/danverse/domain/performance/service/PerformancePureService.java
+++ b/src/main/java/dnd/danverse/domain/performance/service/PerformancePureService.java
@@ -1,7 +1,10 @@
 package dnd.danverse.domain.performance.service;
 
+import static dnd.danverse.global.exception.ErrorCode.PERFORMANCE_NOT_FOUND;
+
 import dnd.danverse.domain.performance.dto.response.ImminentPerformsDto;
 import dnd.danverse.domain.performance.entity.Performance;
+import dnd.danverse.domain.performance.exception.PerformanceNotFoundException;
 import dnd.danverse.domain.performance.repository.PerformanceRepository;
 import java.time.LocalDate;
 import java.util.List;
@@ -11,7 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * 공연 순수 서비스
+ * 공연 순수 서비스.
  */
 @Service
 @RequiredArgsConstructor
@@ -32,5 +35,11 @@ public class PerformancePureService {
         .map(ImminentPerformsDto::new)
         .limit(4)
         .collect(Collectors.toList());
+  }
+
+  @Transactional(readOnly = true)
+  public Performance getPerformanceDetail(Long performId) {
+    return performanceRepository.findPerformanceWithProfile(performId)
+        .orElseThrow(() -> new PerformanceNotFoundException(PERFORMANCE_NOT_FOUND));
   }
 }

--- a/src/main/java/dnd/danverse/domain/performgenre/repository/PerformGenreRepository.java
+++ b/src/main/java/dnd/danverse/domain/performgenre/repository/PerformGenreRepository.java
@@ -1,4 +1,4 @@
-package dnd.danverse.domain.performgenre;
+package dnd.danverse.domain.performgenre.repository;
 
 import dnd.danverse.domain.performgenre.entity.PerformGenre;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/dnd/danverse/global/exception/ErrorCode.java
+++ b/src/main/java/dnd/danverse/global/exception/ErrorCode.java
@@ -30,6 +30,9 @@ public enum ErrorCode {
 
   EVENT_ALREADY_APPLIED(HttpStatus.BAD_REQUEST, "EM003", "이미 지원한 이벤트입니다. 중복으로 지원할 수 없습니다."),
 
+  // 공연
+  PERFORMANCE_NOT_FOUND(HttpStatus.NOT_FOUND, "PF001", "존재하지 않는 공연 정보입니다."),
+
 
   // 회원 member
   MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "M001", "존재하지 않는 회원입니다."),

--- a/src/test/java/dnd/danverse/domain/performance/repository/PerformanceRepositoryTest.java
+++ b/src/test/java/dnd/danverse/domain/performance/repository/PerformanceRepositoryTest.java
@@ -9,7 +9,7 @@ import dnd.danverse.domain.member.entity.Role;
 import dnd.danverse.domain.member.repository.MemberRepository;
 import dnd.danverse.domain.oauth.info.OAuth2Provider;
 import dnd.danverse.domain.performance.entity.Performance;
-import dnd.danverse.domain.performgenre.PerformGenreRepository;
+import dnd.danverse.domain.performgenre.repository.PerformGenreRepository;
 import dnd.danverse.domain.performgenre.entity.PerformGenre;
 import dnd.danverse.domain.profile.ProfileRepository;
 import dnd.danverse.domain.profile.entity.OpenChat;


### PR DESCRIPTION
### ✒️ 관련 이슈번호

- Close #83 

## 🔑 Key Changes

1. 공연 정보 상세조회 메서드를 Controller에 추가
2. repository에 공연정보와 프로필을 fetch join하는 메서드 추가
3. 공연 정보 responseDto 추가

## 📢 To Reviewers

- None