### PR TITLE
[Feat] : 이벤트 글 삭제 기능 구현 

### DIFF
--- a/src/main/java/dnd/danverse/domain/event/controller/EventController.java
+++ b/src/main/java/dnd/danverse/domain/event/controller/EventController.java
@@ -5,6 +5,7 @@ import dnd.danverse.domain.event.dto.request.EventSavedRequestDto;
 import dnd.danverse.domain.event.dto.request.EventUpdateRequestDto;
 import dnd.danverse.domain.event.dto.response.EventInfoResponse;
 import dnd.danverse.domain.event.dto.response.EventWithProfileDto;
+import dnd.danverse.domain.event.service.EventDeleteService;
 import dnd.danverse.domain.event.service.EventFilterService;
 import dnd.danverse.domain.event.service.EventSaveComplexService;
 import dnd.danverse.domain.event.service.EventSearchComplexService;
@@ -16,12 +17,14 @@ import dnd.danverse.global.response.DataResponse;
 import dnd.danverse.global.response.MessageResponse;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -43,6 +46,7 @@ public class EventController {
   private final EventSaveComplexService eventSaveComplexService;
   private final EventSearchComplexService eventSearchComplexService;
   private final EventUpdateService eventUpdateService;
+  private final EventDeleteService eventDeleteService;
 
   /**
    * 이벤트 필터링과, 페이징을 적용한 이벤트 조회.
@@ -97,6 +101,7 @@ public class EventController {
 
   /**
    * 이벤트 모집 기한을 조기 마감 시킬 수 있다.
+   *
    * @return "조기 마감 성공" 메시지와 함께 200 상태코드가 나타납니다.
    */
   @PatchMapping("/deadline")
@@ -120,6 +125,22 @@ public class EventController {
     EventWithProfileDto responseDto = eventUpdateService.updateEventInfo(requestDto,
         sessionUser.getId());
     return new ResponseEntity<>(DataResponse.of(HttpStatus.OK, "이벤트 수정 성공", responseDto), HttpStatus.OK);
+  }
+
+  /**
+   * 이벤트 글 삭제할 수 있다.
+   */
+  @DeleteMapping("/{eventId}")
+  @ApiOperation(value = "이벤트 글 삭제", notes = "이벤트 글을 삭제할 수 있다.")
+  @ApiImplicitParams({
+      @ApiImplicitParam(name = "eventId", value = "이벤트 고유 ID", required = true),
+      @ApiImplicitParam(name = "Authorization", value = "Bearer access_token (서버에서 발급한 access_token)",
+          required = true, dataType = "string", paramType = "header")
+  })
+  public ResponseEntity<MessageResponse> deleteEvent(@PathVariable("eventId") Long eventId,
+      @AuthenticationPrincipal SessionUser sessionUser) {
+    eventDeleteService.deleteEvent(eventId, sessionUser.getId());
+    return new ResponseEntity<>(MessageResponse.of(HttpStatus.OK, "이벤트 삭제 성공"), HttpStatus.OK);
   }
 
 }

--- a/src/main/java/dnd/danverse/domain/event/service/EventDeleteService.java
+++ b/src/main/java/dnd/danverse/domain/event/service/EventDeleteService.java
@@ -1,0 +1,30 @@
+package dnd.danverse.domain.event.service;
+
+import dnd.danverse.domain.event.entitiy.Event;
+import dnd.danverse.domain.matching.service.EventWriterValidationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * 이벤트 삭제 복합 서비스.
+ */
+@Service
+@RequiredArgsConstructor
+public class EventDeleteService {
+
+  private final EventPureService eventPureService;
+  private final EventWriterValidationService eventWriterValidationService;
+
+  /**
+   * 작성자가 이벤트를 삭제할 수 있습니다.
+   *
+   * @param eventId 이벤트 고유 Id.
+   * @param memberId 삭제 요청 보낸 멤버 Id.
+   */
+  public void deleteEvent(Long eventId, Long memberId) {
+    eventWriterValidationService.validateEventWriter(eventId, memberId);
+    Event event = eventPureService.checkIfDeleted(eventId);
+    eventPureService.deleteEvent(event);
+  }
+
+}

--- a/src/main/java/dnd/danverse/domain/event/service/EventPureService.java
+++ b/src/main/java/dnd/danverse/domain/event/service/EventPureService.java
@@ -88,6 +88,7 @@ public class EventPureService {
 
   /**
    * 지금 시간으로 마감 기한을 업데이트 한다.
+   *
    * @param eventId 이벤트 고유 ID
    */
   @Transactional
@@ -102,5 +103,10 @@ public class EventPureService {
     Event event = getEvent(eventId);
     event.updateEventInfo(requestDto);
     return event;
+  }
+
+  @Transactional
+  public void deleteEvent(Event event) {
+    eventRepository.delete(event);
   }
 }

--- a/src/main/java/dnd/danverse/global/security/config/SecurityConfig.java
+++ b/src/main/java/dnd/danverse/global/security/config/SecurityConfig.java
@@ -47,7 +47,7 @@ public class SecurityConfig {
         .antMatchers(HttpMethod.POST, "/api/v1/events", "/api/v1/events/apply",
             "/api/v1/events/image", "/api/v1/performances/image", "/api/v1/profiles/image")
           .hasAuthority(userRole)
-        .antMatchers(HttpMethod.DELETE, "/api/v1/events/{eventId}/cancel-apply")
+        .antMatchers(HttpMethod.DELETE, "/api/v1/events/{eventId}/cancel-apply", "/api/v1/events/{eventId}")
           .hasAuthority(userRole)
         .antMatchers(HttpMethod.GET, "/api/v1/events/{eventId}/applicants").hasAuthority(userRole)
         .antMatchers(HttpMethod.PATCH, "/api/v1/events/{eventId}/accept", "/api/v1/events/deadline")


### PR DESCRIPTION
### ✒️ 관련 이슈번호

- Close #92 

## 🔑 Key Changes

1. 이벤트 컨트롤러에 글을 삭제할 수 있는 메서드 추가
2. 이벤트 삭제 복합 서비스에서 삭제 요청한 사람과 작성자가 같은 사람인지 판단하고 삭제하는 메서드 추가 
3. Swagger 연동
4. security config에 삭제 요청 url 추가

## 📢 To Reviewers

- None