### PR TITLE
[Refactor] : 공연 전체 조회 코드 개선 (데이터 뻥튀기 현상 해결)

### DIFF
--- a/src/main/java/dnd/danverse/domain/performance/controller/PerformanceController.java
+++ b/src/main/java/dnd/danverse/domain/performance/controller/PerformanceController.java
@@ -41,6 +41,7 @@ public class PerformanceController {
    * @return 임박한 공연 목록
    */
   @GetMapping("/imminent")
+  @ApiOperation(value = "임박한 공연 조회", notes = "오늘 날짜 기준으로, 최근 공연 4개를 조회할 수 있다.")
   public ResponseEntity<DataResponse<List<ImminentPerformsDto>>> searchImminentPerformance() {
 
     List<ImminentPerformsDto> performs = performancePureService.searchImminentPerforms();
@@ -55,6 +56,7 @@ public class PerformanceController {
    * @return 페이징 처리된 공연 목록
    */
   @GetMapping()
+  @ApiOperation(value = "공연 전체 조회", notes = "공연 필터링(지역,장르)와 날짜(월,일별), 페이징을 적용한 공연 조회.")
   public ResponseEntity<DataResponse<PageDto<PerformInfoResponse>>> searchPerformanceWithCond(
       PerformCondDto performCondDto, Pageable pageable) {
 

--- a/src/main/java/dnd/danverse/domain/performance/dto/request/PerformCondDto.java
+++ b/src/main/java/dnd/danverse/domain/performance/dto/request/PerformCondDto.java
@@ -1,5 +1,6 @@
 package dnd.danverse.domain.performance.dto.request;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -15,20 +16,30 @@ import lombok.Getter;
 public class PerformCondDto {
 
   /**
+   * 공연 시작하는 년도
+   */
+  @ApiModelProperty(value = "공연 시작하는 년도")
+  private Integer year;
+
+  /**
    * 공연 시작하는 월
    */
+  @ApiModelProperty(value = "공연 시작하는 월")
   private Integer month;
   /**
    * 공연 시작하는 일
    */
+  @ApiModelProperty(value = "공연 시작하는 일")
   private Integer day;
   /**
    * 공연 지역
    */
+  @ApiModelProperty(value = "공연 지역")
   private String location;
   /**
    * 공연 장르
    */
+  @ApiModelProperty(value = "공연 장르")
   private String genre;
 
 }

--- a/src/main/java/dnd/danverse/domain/performance/dto/response/ImminentPerformsDto.java
+++ b/src/main/java/dnd/danverse/domain/performance/dto/response/ImminentPerformsDto.java
@@ -1,6 +1,7 @@
 package dnd.danverse.domain.performance.dto.response;
 
 import dnd.danverse.domain.performance.entity.Performance;
+import io.swagger.annotations.ApiModelProperty;
 import java.time.LocalDate;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -18,25 +19,29 @@ public class ImminentPerformsDto {
   /**
    * 공연 ID
    */
+  @ApiModelProperty(value = "공연 고유 ID")
   private final Long id;
 
   /**
    * 공연 제목
    */
+  @ApiModelProperty(value = "공연 제목")
   private final String title;
   /**
    * 공연 시작 날짜
    */
+  @ApiModelProperty(value = "공연 시작 날짜")
   private final LocalDate startDate;
   /**
    * 공연 이미지
    */
-  private final String image;
+  @ApiModelProperty(value = "공연 이미지 URL")
+  private final String imgUrl;
 
   public ImminentPerformsDto(Performance performance) {
     this.id = performance.getId();
     this.title = performance.getTitle();
     this.startDate = performance.getStartDate();
-    this.image = performance.getPerformanceImg().getImageUrl();
+    this.imgUrl = performance.getPerformanceImg().getImageUrl();
   }
 }

--- a/src/main/java/dnd/danverse/domain/performance/dto/response/PerformInfoResponse.java
+++ b/src/main/java/dnd/danverse/domain/performance/dto/response/PerformInfoResponse.java
@@ -1,7 +1,8 @@
 package dnd.danverse.domain.performance.dto.response;
 
-import com.querydsl.core.annotations.QueryProjection;
 import dnd.danverse.domain.performance.entity.Performance;
+import dnd.danverse.domain.profile.dto.response.ProfileSimpleDto;
+import io.swagger.annotations.ApiModelProperty;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -14,45 +15,38 @@ import lombok.Getter;
 public class PerformInfoResponse {
 
   // 공연
-  private final Long performId;
-  private final String performTitle;
-  private final String performImg;
-  private final LocalDate performStartDate;
-  private final List<String> performGenres;
-  private final String performLocation;
+  @ApiModelProperty(value = "공연 고유 ID")
+  private final Long id;
+  @ApiModelProperty(value = "공연 제목")
+  private final String title;
+  @ApiModelProperty(value = "공연 이미지 URL")
+  private final String imgUrl;
+  @ApiModelProperty(value = "공연 시작 날짜")
+  private final LocalDate startDate;
+  @ApiModelProperty(value = "공연 장르")
+  private final List<String> genres;
+  @ApiModelProperty(value = "공연 장소")
+  private final String location;
 
   // 공연 주최자
-  private final Long profileId;
-  private final String profileImg;
-  private final String profileName;
+  @ApiModelProperty(value = "공연 주최자 프로필")
+  private final ProfileSimpleDto profile;
 
-  @QueryProjection
-  public PerformInfoResponse(Long performId, String performTitle, String performImg, LocalDate performStartDate, List<String> performGenres, String performLocation, Long profileId, String profileImg, String profileName) {
-    this.performId = performId;
-    this.performTitle = performTitle;
-    this.performImg = performImg;
-    this.performStartDate = performStartDate;
-    this.performGenres = performGenres;
-    this.performLocation = performLocation;
-    this.profileId = profileId;
-    this.profileImg = profileImg;
-    this.profileName = profileName;
-  }
 
   /**
    * Entity to Dto
+   * performance.getProfileHost() 시점에 N +1 문제가 발생하지만
+   * Batch Size 를 통해 해결한다.
    * @param performance 공연
    */
   public PerformInfoResponse (Performance performance) {
-    this.performId = performance.getId();
-    this.performTitle = performance.getTitle();
-    this.performImg = performance.getPerformanceImg().getImageUrl();
-    this.performStartDate = performance.getStartDate();
-    this.performGenres = performance.getPerformGenres();
-    this.performLocation = performance.getLocation();
-    this.profileId = performance.getProfileHost().getId();
-    this.profileImg = performance.getProfileHost().getProfileImg().getImageUrl();
-    this.profileName = performance.getProfileHost().getProfileName();
+    this.id = performance.getId();
+    this.title = performance.getTitle();
+    this.imgUrl = performance.getPerformanceImg().getImageUrl();
+    this.startDate = performance.getStartDate();
+    this.genres = performance.getPerformGenres();
+    this.location = performance.getLocation();
+    this.profile = new ProfileSimpleDto(performance.getProfileHost());
   }
 
   /**

--- a/src/main/java/dnd/danverse/domain/performance/repository/PerformanceRepositoryImpl.java
+++ b/src/main/java/dnd/danverse/domain/performance/repository/PerformanceRepositoryImpl.java
@@ -2,7 +2,6 @@ package dnd.danverse.domain.performance.repository;
 
 import static dnd.danverse.domain.performance.entity.QPerformance.performance;
 import static dnd.danverse.domain.performgenre.entity.QPerformGenre.performGenre;
-import static dnd.danverse.domain.profile.entity.QProfile.profile;
 import static org.aspectj.util.LangUtil.isEmpty;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -30,6 +29,35 @@ public class PerformanceRepositoryImpl implements PerformFilterCustom {
 
   /**
    * 공연 필터링 조건을 통해 공연을 조회 (페이징 처리)
+   * content 를 가져오는 경우에는 일대다 컬렉션 fetch join 이더라도 데이터 뻥튀기에 상관 없이 원하는
+   * 결과 값을 얻을 수 있다.
+   * 데이터 뻥튀기의 가장 큰 문제는 count 쿼리가 발생할 때 발생한다.
+   *
+   * 페이징에 필요한 content 를 가져오기 위해 시도 했던 방향
+   * 1. 공연(1) + 주최자(1) + 장르(N) 모두 join 을 하고자 했다. (하지만, table 조인 시 공연, 주최자 데이터에 대해서는 장르 데이터 개수에 만큼 데이터 중복 현상이 발생한다.)
+   * 2. 공연(1) + 주최자(1) fetch join 을 하고, 장르는 Lazy Loading 을 하고자 했다. 하지만 이렇게 하면 필터링 조건에 장르가 있기 때문에 Lazy Loading의 결과 값으로 장르에 대한 필터링 로직이 더 추가되어야 한다.
+   * 3. 공연(1) + 장르(N) fetch join 을 하고, 주최자는 Lazy Loading 을 하고자 했다. Lazy Loading 발생 문제는 Batch Size 로 해결 가능.
+   *
+   * 따라서, 1번 방식에서 데이터 중복의 문제점을 최소한으로 줄이기 위해 3번 방식을 선택하였다.
+   * Entity 를 Dto 로 변환하는 과정에서 공연 주최자 데이터를 얻기 위해 profile 객체를 가져오는데 N + 1 문제를 해결하기 위해
+   * Batch Size 100 을 활용하였다. select * from profile where profile_id in ( ?, ?, ? ~ 100개) 로 한번에 가져온다.
+   * ? 에 들어가는 값은 공연 주최자의 id 값이다.
+   *
+   * count query 연산 시 문제점
+   * 1,2,3번 모두 페이지에 필요한 content 를 가져오는데는 아무런 문제가 없다.
+   * 하지만, count 쿼리를 날릴 때,
+   * 1번, 2번, 3번 모두 count query 를 계산할때 , 일대다 컬렉션 조인이 이루어지고 있다.
+   * 이러한 일대다 컬렉션 조인은 데이터 뻥튀기 현상이 발생한다. count query 연산에 있어서 데이터 정합성이 깨진다.
+   *
+   * count Query 를 위해서는 일단 무조건 공연(1) + 장르(N)는 같이 join 이 이루어져야 한다.
+   * 왜냐하면, 필터링 조건이 공연과 장르에 모두 존재하기 때문이다.
+   * 그러면 어떻게 하면 공연 + 장르 join 을 유지하면서 데이터 뻥튀기 현상을 방지할 수 있을까?
+   * 바로 select 의 결과 값을 distinct 를 통해 조회된 공연(1)을 기준으로 disctinct 를 해주면 된다.
+   * 우리가 최종적으로 원한 건, 공연 장르에 대한 데이터 개수가 궁금한게 아니라
+   * 공연 데이터 개수가 궁금한 것이다.
+   *
+   * https://joont92.github.io/jpa/JPA-%EC%84%B1%EB%8A%A5-%EC%B5%9C%EC%A0%81%ED%99%94/
+   * https://wangtak.tistory.com/30
    * @param performCondDto 공연 필터링 조건
    * @param pageable 페이징 처리
    * @return 페이징 처리된 공연 정보
@@ -41,14 +69,15 @@ public class PerformanceRepositoryImpl implements PerformFilterCustom {
     List<Performance> performContent = queryFactory
         .select(performance)
         .from(performance)
-        .join(performance.profileHost, profile).fetchJoin()
         .join(performance.performGenres, performGenre).fetchJoin()
         .where(
+            yearEq(performCondDto.getYear()),
             monthEq(performCondDto.getMonth()),
             dayEq(performCondDto.getDay()),
             locationEq(performCondDto.getLocation()),
-            genreEq(performCondDto.getGenre())
+            genreIn(performCondDto.getGenre())
         )
+        .orderBy(performance.createdAt.desc())
         .offset(pageable.getOffset())
         .limit(pageable.getPageSize())
         .fetch();
@@ -64,23 +93,45 @@ public class PerformanceRepositoryImpl implements PerformFilterCustom {
    * 필터링 조건이 performance 와 performGenre 에서 모두 사용되므로
    * countQuery 에서는 join 을 통해 두 테이블을 조인하여 사용 (성능 향상)
    * profileHost 는 필요없으므로 join 을 사용 안함
+   *
+   * 현재 collection을 기준으로 일대다 조인이 발생하기 때문에, 데이터 뻥튀기 현상이 발생하고 있다.
+   *
+   * 공연(1) + 장르(N) join 을 하여 count Query 연산을 하려고 한다.
+   * 그 이유는 필터링 조건에 공연 + 장르 조건이 모두 존재하기 때문이다.
+   * 하지만, 데이터 중복 현상 (데이터 뻥튀기 현상) 이 발생하고 있다.
+   * 이를 해결하기 위해 select 에서 가져온 공연(1)을 기준으로 distinct 를 해주면 된다.
+   * 물론 distinct 를 한다고 table 조인 시, 데이터 중복 현상이 막아지는건 아니다.
+   * 단순히, 데이터 중복 현상이 발생하고 있는 결과 table 에 distinct 함수를 통해
+   * 공연 size 에 대한 count 를 해주는 것이다. (핵심, 데이터 중복 현상이 해결되는건 아니다, 데이터 개수 카운팅에만 중복을 제거해준다.)
+   *
    * @param performCondDto 공연 필터링 조건
    * @return 공연 전체 개수
    */
   private long getTotalCount(PerformCondDto performCondDto) {
 
     JPAQuery<Performance> countQuery = queryFactory
-        .select(performance)
+        .select(performance).distinct()
         .from(performance)
         .join(performance.performGenres, performGenre)
         .where(
             monthEq(performCondDto.getMonth()),
             dayEq(performCondDto.getDay()),
             locationEq(performCondDto.getLocation()),
-            genreEq(performCondDto.getGenre())
+            genreIn(performCondDto.getGenre())
         );
 
     return countQuery.fetch().size();
+  }
+
+
+  /**
+   * year 가 일치하는 경우 where 절에 추가
+   * year 가 null 인 경우 where 절에 추가하지 않음
+   * @param year 공연 년도
+   * @return year 가 일치하는 경우 where 절에 추가
+   */
+  private BooleanExpression yearEq(Integer year) {
+    return year == null ? null : performance.startDate.year().eq(year);
   }
 
   /**
@@ -114,13 +165,13 @@ public class PerformanceRepositoryImpl implements PerformFilterCustom {
   }
 
   /**
-   * genre 가 일치하는 경우 where 절에 추가
+   * genre 가 하나라도 존재 하는 경우 where 절에 추가
    * genre 가 null 인 경우 where 절에 추가하지 않음
    * @param genre 공연 장르
    * @return genre 가 일치하는 경우 where 절에 추가
    */
-  private BooleanExpression genreEq(String genre) {
-    return isEmpty(genre) ? null : performGenre.genre.eq(genre);
+  private BooleanExpression genreIn(String genre) {
+    return isEmpty(genre) ? null : performGenre.genre.contains(genre);
   }
 
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 # active profile
-spring.profiles.active=prod
+spring.profiles.active=dev
 
 
 # Spring boot 2.6버전 이후에 spring.mvc.pathmatch.matching-strategy 값이 ant_apth_matcher에서
@@ -8,3 +8,6 @@ spring.profiles.active=prod
 # localhost:8080/swagger-ui/index.html
 # localhost:8080/v2/api-docs
 spring.mvc.pathmatch.matching-strategy=ant_path_matcher
+
+# data jpa batch size
+spring.jpa.properties.hibernate.default_batch_fetch_size=100

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 # active profile
-spring.profiles.active=dev
+spring.profiles.active=prod
 
 
 # Spring boot 2.6버전 이후에 spring.mvc.pathmatch.matching-strategy 값이 ant_apth_matcher에서


### PR DESCRIPTION
### ✒️ 관련 이슈번호

- Close #97 

## 🔑 Key Changes

1. "공연 + 장르"로 Join을 하여 페이징에 필요한 content를 가져오고, profile에 대한 데이터는 Batch Size을 통해 N + 1문제 해결
2. count Query 연산 시, 일대다 컬렉션 fetch join 시 발생하는, 데이터 뻥튀기 현상을 해결하기 위해 distinct() 함수 사용
3. year 조건을 받을 수 있도록 추가
4. 검색 조건에 담기는 genre 가 하나라도 있을 경우, 데이터 조회 가능하도록 BooleanExpression 추가

## 📢 To Reviewers

- None