### PR TITLE
[Feat] : 공연 정보 등록 기능 구현

### DIFF
--- a/src/main/java/dnd/danverse/domain/performance/controller/PerformanceController.java
+++ b/src/main/java/dnd/danverse/domain/performance/controller/PerformanceController.java
@@ -1,11 +1,14 @@
 package dnd.danverse.domain.performance.controller;
 
+import dnd.danverse.domain.jwt.service.SessionUser;
 import dnd.danverse.domain.performance.dto.request.PerformCondDto;
+import dnd.danverse.domain.performance.dto.request.PerformSavedRequestDto;
 import dnd.danverse.domain.performance.dto.response.ImminentPerformsDto;
 import dnd.danverse.domain.performance.dto.response.PageDto;
 import dnd.danverse.domain.performance.dto.response.PerformDetailResponse;
 import dnd.danverse.domain.performance.dto.response.PerformInfoResponse;
 import dnd.danverse.domain.performance.service.PerformFilterService;
+import dnd.danverse.domain.performance.service.PerformSaveComplexService;
 import dnd.danverse.domain.performance.service.PerformSearchComplexService;
 import dnd.danverse.domain.performance.service.PerformancePureService;
 import dnd.danverse.global.response.DataResponse;
@@ -16,8 +19,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import springfox.documentation.annotations.ApiIgnore;
@@ -34,6 +40,7 @@ public class PerformanceController {
   private final PerformancePureService performancePureService;
   private final PerformFilterService performFilterService;
   private final PerformSearchComplexService performSearchComplexService;
+  private final PerformSaveComplexService performSaveComplexService;
 
   /**
    * 공연이 임박한 공연을 조회할 수 있다. 오늘 날짜 기준으로, 최근 공연 4개를 조회할 수 있다.
@@ -65,6 +72,12 @@ public class PerformanceController {
         DataResponse.of(HttpStatus.OK, "공연 조회 성공", performInfoResponsePageDto), HttpStatus.OK);
   }
 
+  /**
+   * 공연 글 상세 조회.
+   *
+   * @param performId 상세조회하려는 공연 글 Id.
+   * @return 공연 responseDto.
+   */
   @GetMapping("/{performId}")
   @ApiOperation(value = "공연 글 상세조회", notes = "공연 정보 글을 상세 조회할 수 있다.")
   @ApiImplicitParam(name = "performId", value = "공연 고유 ID", required = true)
@@ -73,6 +86,20 @@ public class PerformanceController {
     return new ResponseEntity<>(DataResponse.of(HttpStatus.OK, "공연 상세조회 성공", response), HttpStatus.OK);
   }
 
-
+  /**
+   * 공연 글 등록.
+   *
+   * @param performSavedDto 공연 글 등록하기 위한 요청 Dto.
+   * @param sessionUser 글을 등록하려고 하는 사용자.
+   * @return 등록 성공하면 201 상태코드와 함께 응답 Dto를 반환.
+   */
+  @PostMapping("")
+  @ApiOperation(value = "공연 글 등록", notes = "프로필을 등록한 사용자에 한하여 공연 글을 등록할 수 있다.")
+  @ApiImplicitParam(name = "Authorization", value = "Bearer access_token (서버에서 발급한 access_token)",
+      required = true, dataType = "string", paramType = "header")
+  public ResponseEntity<DataResponse<PerformDetailResponse>> postPerform(@RequestBody PerformSavedRequestDto performSavedDto, @AuthenticationPrincipal SessionUser sessionUser) {
+    PerformDetailResponse response = performSaveComplexService.postPerform(performSavedDto, sessionUser.getId());
+    return new ResponseEntity<>(DataResponse.of(HttpStatus.CREATED, "공연 등록 성공", response), HttpStatus.CREATED);
+  }
 
 }

--- a/src/main/java/dnd/danverse/domain/performance/dto/request/PerformSavedRequestDto.java
+++ b/src/main/java/dnd/danverse/domain/performance/dto/request/PerformSavedRequestDto.java
@@ -1,0 +1,93 @@
+package dnd.danverse.domain.performance.dto.request;
+
+import dnd.danverse.domain.common.Image;
+import dnd.danverse.domain.performance.entity.Performance;
+import dnd.danverse.domain.performgenre.entity.PerformGenre;
+import dnd.danverse.domain.profile.entity.Profile;
+import io.swagger.annotations.ApiModelProperty;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 공연 등록 요청 Dto.
+ */
+@Getter
+@NoArgsConstructor
+public class PerformSavedRequestDto {
+
+  /**
+   * 공연 제목.
+   */
+  @ApiModelProperty(value = "공연 제목")
+  private String title;
+
+  /**
+   * 공연 지역.
+   */
+  @ApiModelProperty(value = "공연 지역")
+  private String location;
+
+  /**
+   * 공연 장소.
+   */
+  @ApiModelProperty(value = "공연 장소")
+  private String address;
+
+  /**
+   * 공연 시작 날짜.
+   */
+  @ApiModelProperty(value = "공연 시작 날짜")
+  private LocalDate startDate;
+
+  /**
+   * 공연 시작 시간.
+   */
+  @ApiModelProperty(value = "공연 시작 시간")
+  private LocalDateTime startTime;
+
+  /**
+   * 공연 장르 리스트(최대 3개까지).
+   */
+  @ApiModelProperty(value = "공연 장르 리스트")
+  private List<String> genres;
+
+  /**
+   * 공연 포스터 Url.
+   */
+  @ApiModelProperty(value = "공연 포스터 Url")
+  private String imgUrl;
+
+  /**
+   * 공연 상세설명.
+   */
+  @ApiModelProperty(value = "공연 상세 설명")
+  private String description;
+
+  /**
+   * dto to Entity.
+   *
+   * @param profile 공연 주최자 프로필.
+   * @return dto에서 변환된 entity.
+   */
+  public Performance toEntity(Profile profile) {
+    return Performance.builder()
+        .title(this.title)
+        .performanceImg(new Image(this.imgUrl))
+        .startDate(this.startDate)
+        .startTime(this.startTime)
+        .location(this.location)
+        .performGenres(this.getGenres().stream()
+            .map(PerformGenre::new)
+            .collect(Collectors.toList()))
+        .description(this.description)
+        .address(this.address)
+        .profileHost(profile)
+        .build();
+  }
+
+
+}

--- a/src/main/java/dnd/danverse/domain/performance/entity/Performance.java
+++ b/src/main/java/dnd/danverse/domain/performance/entity/Performance.java
@@ -29,7 +29,7 @@ import org.hibernate.annotations.OnDeleteAction;
 import org.hibernate.annotations.Parameter;
 
 /**
- * 공연 Entity
+ * 공연 Entity.
  */
 @Entity
 @NoArgsConstructor
@@ -46,14 +46,14 @@ import org.hibernate.annotations.Parameter;
 public class Performance extends BaseTimeEntity {
 
   /**
-   * 공연 고유 ID, 시퀀스 전략 사용
+   * 공연 고유 ID, 시퀀스 전략 사용.
    */
   @Id
   @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "PERFORMANCE_SEQ_GENERATOR")
   private Long id;
 
   /**
-   * 공연 주최자
+   * 공연 주최자.
    */
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "profile_host_id", nullable = false, foreignKey = @ForeignKey(name = "FK_PERFORMANCE_PROFILE_HOST"))
@@ -64,48 +64,48 @@ public class Performance extends BaseTimeEntity {
    * 공연 장르 목록 PerformGenre 의 삭제는 Performance 가 삭제될 때 함께 삭제된다. CascadeType.PERSIST 를 하지 않고, 추후
    * saveAll()를 통해서 한번의 네트워크 통신으로 처리한다.
    */
-  @OneToMany(cascade = CascadeType.REMOVE, orphanRemoval = true)
+  @OneToMany(cascade = {CascadeType.REMOVE, CascadeType.PERSIST}, orphanRemoval = true)
   @JoinColumn(name = "performance_id", foreignKey = @ForeignKey(name = "FK_PERFORMGENRE_PERFORMANCE"))
   private List<PerformGenre> performGenres = new ArrayList<>();
 
   /**
-   * 공연 제목
+   * 공연 제목.
    */
   @Column(nullable = false)
   private String title;
 
   /**
-   * 공연 위치(지역)
+   * 공연 위치(지역).
    */
   @Column(nullable = false)
   private String location;
 
   /**
-   * 공연 구체적인 장소
+   * 공연 구체적인 장소.
    */
   @Column(nullable = false)
   private String address;
 
   /**
-   * 공연 시작 날짜 (년, 월, 일)
+   * 공연 시작 날짜 (년, 월, 일).
    */
   @Column(nullable = false)
   private LocalDate startDate;
 
   /**
-   * 공연 시작 시간 (년, 월, 일, 시, 분, 초)
+   * 공연 시작 시간 (년, 월, 일, 시, 분, 초).
    */
   @Column(nullable = false)
   private LocalDateTime startTime;
 
   /**
-   * 공연 포스터 이미지
+   * 공연 포스터 이미지.
    */
   @Embedded
   private Image performanceImg;
 
   /**
-   * 공연 설명
+   * 공연 설명.
    */
   @Column(nullable = false)
   private String description;
@@ -128,7 +128,8 @@ public class Performance extends BaseTimeEntity {
 
   /**
    * 공연 장르 목록을 문자열로 반환한다.
-   * @return 장르 목록
+   * 
+   * @return 장르 List
    */
   public List<String> getPerformGenres() {
     List<String> genres = new ArrayList<>();

--- a/src/main/java/dnd/danverse/domain/performance/service/PerformSaveComplexService.java
+++ b/src/main/java/dnd/danverse/domain/performance/service/PerformSaveComplexService.java
@@ -1,0 +1,30 @@
+package dnd.danverse.domain.performance.service;
+
+import dnd.danverse.domain.performance.dto.request.PerformSavedRequestDto;
+import dnd.danverse.domain.performance.dto.response.PerformDetailResponse;
+import dnd.danverse.domain.performance.entity.Performance;
+import dnd.danverse.domain.performgenre.service.PerformGenrePureService;
+import dnd.danverse.domain.profile.entity.Profile;
+import dnd.danverse.domain.profile.service.ProfilePureService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * 공연 등록 복합 서비스.
+ */
+@Service
+@RequiredArgsConstructor
+public class PerformSaveComplexService {
+  private final PerformancePureService performancePureService;
+  private final ProfilePureService profilePureService;
+  private final PerformGenrePureService performGenrePureService;
+
+
+  public PerformDetailResponse postPerform(PerformSavedRequestDto performSavedRequest, Long memberId) {
+    Profile writer = profilePureService.retrieveProfile(memberId);
+    Performance performance = performancePureService.createPerform(performSavedRequest.toEntity(writer));
+    performGenrePureService.smallerThanThree(performance.getPerformGenres());
+
+    return new PerformDetailResponse(performance);
+  }
+}

--- a/src/main/java/dnd/danverse/domain/performance/service/PerformancePureService.java
+++ b/src/main/java/dnd/danverse/domain/performance/service/PerformancePureService.java
@@ -42,4 +42,11 @@ public class PerformancePureService {
     return performanceRepository.findPerformanceWithProfile(performId)
         .orElseThrow(() -> new PerformanceNotFoundException(PERFORMANCE_NOT_FOUND));
   }
+
+  @Transactional
+  public Performance createPerform(Performance performance) {
+    return performanceRepository.save(performance);
+  }
+
+
 }

--- a/src/main/java/dnd/danverse/domain/performgenre/exception/LimitExceededException.java
+++ b/src/main/java/dnd/danverse/domain/performgenre/exception/LimitExceededException.java
@@ -1,0 +1,13 @@
+package dnd.danverse.domain.performgenre.exception;
+
+import dnd.danverse.global.exception.BusinessException;
+import dnd.danverse.global.exception.ErrorCode;
+
+/**
+ * 장르를 3개 초과하여 선택하면 예외 발생한다.
+ */
+public class LimitExceededException extends BusinessException {
+  public LimitExceededException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+}

--- a/src/main/java/dnd/danverse/domain/performgenre/service/PerformGenrePureService.java
+++ b/src/main/java/dnd/danverse/domain/performgenre/service/PerformGenrePureService.java
@@ -1,0 +1,26 @@
+package dnd.danverse.domain.performgenre.service;
+
+import dnd.danverse.domain.performgenre.exception.LimitExceededException;
+import dnd.danverse.global.exception.ErrorCode;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * 공연 장르 순수 서비스.
+ */
+@Service
+@RequiredArgsConstructor
+public class PerformGenrePureService {
+
+  /**
+   * 장르 리스트의 사이즈가 3보다 크면 LimitExceededException 이 발생한다.
+   *
+   * @param genre 장르의 List.
+   */
+  public void smallerThanThree(List<String> genre) {
+    if (genre.size() > 3) {
+      throw new LimitExceededException(ErrorCode.PERFORM_GENRE_EXCEEDED);
+    }
+  }
+}

--- a/src/main/java/dnd/danverse/global/exception/ErrorCode.java
+++ b/src/main/java/dnd/danverse/global/exception/ErrorCode.java
@@ -32,6 +32,7 @@ public enum ErrorCode {
 
   // 공연
   PERFORMANCE_NOT_FOUND(HttpStatus.NOT_FOUND, "PF001", "존재하지 않는 공연 정보입니다."),
+  PERFORM_GENRE_EXCEEDED(HttpStatus.BAD_REQUEST, "PG001", "장르는 최대 3개까지 선택 가능합니다."),
 
 
   // 회원 member


### PR DESCRIPTION
### ✒️ 관련 이슈번호

- Close #94 

## 🔑 Key Changes

1. Performance를 저장할 때 genre도 함께 저장하게 만들기 위해서, performance 엔티티의 genre필드에 cascadeType = PERSIST 속성을 함께 추가했습니다.
2. 공연 등록 요청 Dto와 관련 검증 로직, 저장 로직을 구현했습니다.

## 📢 To Reviewers

- insert되는 쿼리가 현재 최적화되어 있지 않아, refactoring이 필요할 것 같습니다. 