### PR TITLE
[Feat] : 팀 이름으로 예정된, 만료된 공연 조회 기능 추가

### DIFF
--- a/src/main/java/dnd/danverse/domain/performance/controller/PerformanceController.java
+++ b/src/main/java/dnd/danverse/domain/performance/controller/PerformanceController.java
@@ -5,6 +5,7 @@ import dnd.danverse.domain.performance.dto.response.ImminentPerformsDto;
 import dnd.danverse.domain.performance.dto.response.PageDto;
 import dnd.danverse.domain.performance.dto.response.PerformDetailResponse;
 import dnd.danverse.domain.performance.dto.response.PerformInfoResponse;
+import dnd.danverse.domain.performance.dto.response.PerformListResponse;
 import dnd.danverse.domain.performance.service.PerformFilterService;
 import dnd.danverse.domain.performance.service.PerformSearchComplexService;
 import dnd.danverse.domain.performance.service.PerformancePureService;
@@ -19,6 +20,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import springfox.documentation.annotations.ApiIgnore;
 
@@ -65,6 +67,14 @@ public class PerformanceController {
 
     return new ResponseEntity<>(
         DataResponse.of(HttpStatus.OK, "공연 조회 성공", performInfoResponsePageDto), HttpStatus.OK);
+  }
+
+  @GetMapping("/team")
+  @ApiOperation(value = "팀 이름으로 공연 조회", notes = "팀 이름으로 공연을 조회할 수 있다.")
+  @ApiImplicitParam(name = "name", value = "팀 이름", required = true)
+  public ResponseEntity<DataResponse<PerformListResponse>> searchPerformsByTeam(@RequestParam("name") String teamName) {
+    PerformListResponse performListResponse = performFilterService.searchPerformsByTeam(teamName);
+    return new ResponseEntity<>(DataResponse.of(HttpStatus.OK, "팀 이름으로 공연 조회 성공", performListResponse), HttpStatus.OK);
   }
 
   @GetMapping("/{performId}")

--- a/src/main/java/dnd/danverse/domain/performance/dto/response/PerformListResponse.java
+++ b/src/main/java/dnd/danverse/domain/performance/dto/response/PerformListResponse.java
@@ -1,0 +1,32 @@
+package dnd.danverse.domain.performance.dto.response;
+
+import dnd.danverse.domain.performance.entity.Performance;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+/**
+ * 예정된 공연 , 마감된 공연을 응답으로 보내주기 위한 Dto.
+ */
+@Getter
+public class PerformListResponse {
+
+  @ApiModelProperty(value = "예정된 공연")
+  private final List<PerformInfoResponse> comming;
+
+  @ApiModelProperty(value = "마감된 공연")
+  private final List<PerformInfoResponse> ended;
+
+  /**
+   * true 는 예정된 공연, false 는 마감된 공연을 응답으로 보내주기 위한 Dto.
+   * @param performMap 예정된 공연, 마감된 공연을 담은 Map
+   */
+  public PerformListResponse(Map<Boolean, List<Performance>> performMap) {
+    this.comming = PerformInfoResponse.of(performMap.get(true));
+    this.ended = PerformInfoResponse.of(performMap.get(false));
+  }
+
+
+
+}

--- a/src/main/java/dnd/danverse/domain/performance/repository/PerformFilterCustom.java
+++ b/src/main/java/dnd/danverse/domain/performance/repository/PerformFilterCustom.java
@@ -2,6 +2,8 @@ package dnd.danverse.domain.performance.repository;
 
 import dnd.danverse.domain.performance.dto.request.PerformCondDto;
 import dnd.danverse.domain.performance.dto.response.PerformInfoResponse;
+import dnd.danverse.domain.performance.entity.Performance;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -11,6 +13,8 @@ import org.springframework.data.domain.Pageable;
 public interface PerformFilterCustom {
 
   Page<PerformInfoResponse> searchAllPerformWithCond(PerformCondDto performCondDto, Pageable pageable);
+
+  List<Performance> searchPerformsByTeam(String teamName);
 
 
 }

--- a/src/main/java/dnd/danverse/domain/performance/repository/PerformanceRepositoryImpl.java
+++ b/src/main/java/dnd/danverse/domain/performance/repository/PerformanceRepositoryImpl.java
@@ -2,6 +2,7 @@ package dnd.danverse.domain.performance.repository;
 
 import static dnd.danverse.domain.performance.entity.QPerformance.performance;
 import static dnd.danverse.domain.performgenre.entity.QPerformGenre.performGenre;
+import static dnd.danverse.domain.profile.entity.QProfile.profile;
 import static org.aspectj.util.LangUtil.isEmpty;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -121,6 +122,33 @@ public class PerformanceRepositoryImpl implements PerformFilterCustom {
         );
 
     return countQuery.fetch().size();
+  }
+
+  /**
+   * team name 을 통해서 예정된 공연, 마감된 공연 조회
+   * @param teamName 팀 이름
+   */
+  @Override
+  public List<Performance> searchPerformsByTeam(String teamName) {
+
+      List<Performance> performances = queryFactory
+          .select(performance)
+          .from(performance)
+          .join(performance.profileHost, profile).fetchJoin()
+          .where(teamNameEq(teamName))
+          .fetch();
+
+    return performances;
+  }
+
+  /**
+   * teamName 이 일치하는 경우 where 절에 추가
+   * teamName 이 null 인 경우 where 절에 추가하지 않음
+   * @param teamName 팀 이름
+   * @return teamName 이 일치하는 경우 where 절에 추가
+   */
+  private BooleanExpression teamNameEq(String teamName) {
+    return isEmpty(teamName) ? null : profile.profileName.eq(teamName);
   }
 
 

--- a/src/main/java/dnd/danverse/domain/performance/service/PerformFilterService.java
+++ b/src/main/java/dnd/danverse/domain/performance/service/PerformFilterService.java
@@ -3,7 +3,13 @@ package dnd.danverse.domain.performance.service;
 import dnd.danverse.domain.performance.dto.request.PerformCondDto;
 import dnd.danverse.domain.performance.dto.response.PageDto;
 import dnd.danverse.domain.performance.dto.response.PerformInfoResponse;
+import dnd.danverse.domain.performance.dto.response.PerformListResponse;
+import dnd.danverse.domain.performance.entity.Performance;
 import dnd.danverse.domain.performance.repository.PerformanceRepository;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -26,5 +32,21 @@ public class PerformFilterService {
         performCondDto, pageable);
 
     return new PageDto<>(performInfoResponses);
+  }
+
+  /**
+   * 팀 이름을 통해 예정된 , 마감된 공연을 조회한다.
+   * @param teamName 팀 이름
+   */
+  public PerformListResponse searchPerformsByTeam(String teamName) {
+    List<Performance> performances = performanceRepository.searchPerformsByTeam(teamName);
+
+    LocalDate today = LocalDate.now();
+
+    Map<Boolean, List<Performance>> performList = performances.stream()
+        .collect(Collectors.partitioningBy(
+            performance -> performance.getStartDate().isAfter(today)));
+
+    return new PerformListResponse(performList);
   }
 }


### PR DESCRIPTION
### ✒️ 관련 이슈번호

- Close #99 

## 🔑 Key Changes

1. 팀 이름으로 예정된, 만료된 공연 조회 기능 추가
2. QueryDSL을 활용하여, 컴파일 시점에 SQL 쿼리문을 확인하여 개발할 수 있었습니다.

## 📢 To Reviewers

- None