### PR TITLE
[Feat] : 공연 정보 수정 기능 구현

### DIFF
--- a/src/main/java/dnd/danverse/domain/performance/controller/PerformanceController.java
+++ b/src/main/java/dnd/danverse/domain/performance/controller/PerformanceController.java
@@ -3,6 +3,7 @@ package dnd.danverse.domain.performance.controller;
 import dnd.danverse.domain.jwt.service.SessionUser;
 import dnd.danverse.domain.performance.dto.request.PerformCondDto;
 import dnd.danverse.domain.performance.dto.request.PerformSavedRequestDto;
+import dnd.danverse.domain.performance.dto.request.PerformUpdateRequestDto;
 import dnd.danverse.domain.performance.dto.response.ImminentPerformsDto;
 import dnd.danverse.domain.performance.dto.response.PageDto;
 import dnd.danverse.domain.performance.dto.response.PerformDetailResponse;
@@ -11,6 +12,7 @@ import dnd.danverse.domain.performance.dto.response.PerformListResponse;
 import dnd.danverse.domain.performance.service.PerformFilterService;
 import dnd.danverse.domain.performance.service.PerformSaveComplexService;
 import dnd.danverse.domain.performance.service.PerformSearchComplexService;
+import dnd.danverse.domain.performance.service.PerformUpdateComplexService;
 import dnd.danverse.domain.performance.service.PerformancePureService;
 import dnd.danverse.global.response.DataResponse;
 import io.swagger.annotations.ApiImplicitParam;
@@ -23,6 +25,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -44,6 +47,7 @@ public class PerformanceController {
   private final PerformFilterService performFilterService;
   private final PerformSearchComplexService performSearchComplexService;
   private final PerformSaveComplexService performSaveComplexService;
+  private final PerformUpdateComplexService performUpdateComplexService;
 
   /**
    * 공연이 임박한 공연을 조회할 수 있다. 오늘 날짜 기준으로, 최근 공연 4개를 조회할 수 있다.
@@ -121,6 +125,23 @@ public class PerformanceController {
   public ResponseEntity<DataResponse<PerformDetailResponse>> postPerform(@RequestBody @Validated PerformSavedRequestDto performSavedDto, @AuthenticationPrincipal SessionUser sessionUser) {
     PerformDetailResponse response = performSaveComplexService.postPerform(performSavedDto, sessionUser.getId());
     return new ResponseEntity<>(DataResponse.of(HttpStatus.CREATED, "공연 등록 성공", response), HttpStatus.CREATED);
+  }
+
+  /**
+   * 공연 글 수정.
+   *
+   * @param updateRequest 공연 글 수정을 위한 요청 Dto.
+   * @param sessionUser 글을 수정하려고 하는 사용자.
+   * @return 글 수정에 성공하면 200 상태코드와 함께 응답 Dto를 반환.
+   */
+  @PatchMapping("")
+  @ApiOperation(value = "공연 글 수정", notes = "작성자에 한하여 글을 수정할 수 있다.")
+  @ApiImplicitParam(name = "Authorization", value = "Bearer access_token (서버에서 발급한 access_token)",
+      required = true, dataType = "string", paramType = "header")
+  public ResponseEntity<DataResponse<PerformDetailResponse>> updatePerform(@RequestBody PerformUpdateRequestDto updateRequest
+      , @AuthenticationPrincipal SessionUser sessionUser) {
+    PerformDetailResponse response = performUpdateComplexService.updatePerform(updateRequest, sessionUser.getId());
+    return new ResponseEntity<>(DataResponse.of(HttpStatus.OK, "공연 수정 성공", response), HttpStatus.OK);
   }
 
 }

--- a/src/main/java/dnd/danverse/domain/performance/dto/request/PerformUpdateRequestDto.java
+++ b/src/main/java/dnd/danverse/domain/performance/dto/request/PerformUpdateRequestDto.java
@@ -4,6 +4,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Set;
+import javax.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -53,6 +54,7 @@ public class PerformUpdateRequestDto {
    * 공연 장르 리스트(최대 3개까지).
    */
   @ApiModelProperty(value = "공연 장르 리스트")
+  @Size(max = 3, min = 1, message = "장르는 최대 3개, 최소 1개까지 선택 가능합니다.")
   private Set<String> genres;
 
   /**

--- a/src/main/java/dnd/danverse/domain/performance/dto/request/PerformUpdateRequestDto.java
+++ b/src/main/java/dnd/danverse/domain/performance/dto/request/PerformUpdateRequestDto.java
@@ -1,9 +1,12 @@
 package dnd.danverse.domain.performance.dto.request;
 
+import dnd.danverse.domain.performance.entity.Performance;
+import dnd.danverse.domain.performgenre.entity.PerformGenre;
 import io.swagger.annotations.ApiModelProperty;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -68,5 +71,19 @@ public class PerformUpdateRequestDto {
    */
   @ApiModelProperty(value = "공연 상세 설명")
   private String description;
+
+  /**
+   * 기존의 요청 Dto 에서는 Set<String> 형태로 장르가 담겨있다.
+   * 그러나 실제 엔티티에서는 Set<PerformGenre>이기 때문에, 이를 변환한다.
+   * String -> PerformGenre
+   *
+   * @param performance 장르를 바꾸려고 하는 공연 객체.
+   * @return Set<PerformGenre>
+   */
+  public Set<PerformGenre> stringToGenre(Performance performance) {
+    return this.getGenres().stream()
+        .map(genre -> new PerformGenre(genre, performance))
+        .collect(Collectors.toSet());
+  }
 
 }

--- a/src/main/java/dnd/danverse/domain/performance/dto/request/PerformUpdateRequestDto.java
+++ b/src/main/java/dnd/danverse/domain/performance/dto/request/PerformUpdateRequestDto.java
@@ -1,0 +1,70 @@
+package dnd.danverse.domain.performance.dto.request;
+
+import io.swagger.annotations.ApiModelProperty;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Set;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 공연 수정 요청 Dto.
+ */
+@Getter
+@NoArgsConstructor
+public class PerformUpdateRequestDto {
+
+  /**
+   * 공연 고유 Id.
+   */
+  @ApiModelProperty(value = "공연 id")
+  private Long id;
+  /**
+   * 공연 제목.
+   */
+  @ApiModelProperty(value = "공연 제목")
+  private String title;
+
+  /**
+   * 공연 지역.
+   */
+  @ApiModelProperty(value = "공연 지역")
+  private String location;
+
+  /**
+   * 공연 장소.
+   */
+  @ApiModelProperty(value = "공연 장소")
+  private String address;
+
+  /**
+   * 공연 시작 날짜.
+   */
+  @ApiModelProperty(value = "공연 시작 날짜")
+  private LocalDate startDate;
+
+  /**
+   * 공연 시작 시간.
+   */
+  @ApiModelProperty(value = "공연 시작 시간")
+  private LocalDateTime startTime;
+
+  /**
+   * 공연 장르 리스트(최대 3개까지).
+   */
+  @ApiModelProperty(value = "공연 장르 리스트")
+  private Set<String> genres;
+
+  /**
+   * 공연 포스터 Url.
+   */
+  @ApiModelProperty(value = "공연 포스터 Url")
+  private String imgUrl;
+
+  /**
+   * 공연 상세설명.
+   */
+  @ApiModelProperty(value = "공연 상세 설명")
+  private String description;
+
+}

--- a/src/main/java/dnd/danverse/domain/performance/dto/response/PerformDetailResponse.java
+++ b/src/main/java/dnd/danverse/domain/performance/dto/response/PerformDetailResponse.java
@@ -1,11 +1,14 @@
 package dnd.danverse.domain.performance.dto.response;
 
 import dnd.danverse.domain.performance.entity.Performance;
+import dnd.danverse.domain.performgenre.entity.PerformGenre;
 import dnd.danverse.domain.profile.dto.response.ProfileSimpleDto;
 import io.swagger.annotations.ApiModelProperty;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -84,6 +87,22 @@ public class PerformDetailResponse {
     this.startTime = perform.getStartTime();
     this.location = perform.getLocation();
     this.genres = perform.getStringOfPerformGenres();
+    this.description = perform.getDescription();
+    this.address = perform.getAddress();
+    this.profile = new ProfileSimpleDto(perform.getProfileHost());
+  }
+
+
+  public PerformDetailResponse(Performance perform, Set<PerformGenre> newGenres) {
+    this.id = perform.getId();
+    this.title = perform.getTitle();
+    this.imgUrl = perform.getPerformanceImg().getImageUrl();
+    this.startDate = perform.getStartDate();
+    this.startTime = perform.getStartTime();
+    this.location = perform.getLocation();
+    this.genres = newGenres.stream()
+        .map(PerformGenre::getGenre)
+        .collect(Collectors.toList());
     this.description = perform.getDescription();
     this.address = perform.getAddress();
     this.profile = new ProfileSimpleDto(perform.getProfileHost());

--- a/src/main/java/dnd/danverse/domain/performance/entity/Performance.java
+++ b/src/main/java/dnd/danverse/domain/performance/entity/Performance.java
@@ -2,12 +2,16 @@ package dnd.danverse.domain.performance.entity;
 
 import dnd.danverse.domain.common.BaseTimeEntity;
 import dnd.danverse.domain.common.Image;
+import dnd.danverse.domain.performance.dto.request.PerformUpdateRequestDto;
 import dnd.danverse.domain.performgenre.entity.PerformGenre;
 import dnd.danverse.domain.profile.entity.Profile;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
@@ -64,8 +68,8 @@ public class Performance extends BaseTimeEntity {
    * 공연 장르 목록 PerformGenre 의 삭제는 Performance 가 삭제될 때 함께 삭제된다. CascadeType.PERSIST 를 하지 않고, 추후
    * saveAll()를 통해서 한번의 네트워크 통신으로 처리한다.
    */
-  @OneToMany(mappedBy = "performance", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
-  private List<PerformGenre> performGenres = new ArrayList<>();
+  @OneToMany(mappedBy = "performance", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+  private Set<PerformGenre> performGenres = new HashSet<>();
 
   /**
    * 공연 제목.
@@ -127,7 +131,7 @@ public class Performance extends BaseTimeEntity {
   /**
    * 공연 장르 목록을 문자열로 반환한다.
    * 
-   * @return 장르 List
+   * @return 장르 List.
    */
   public List<String> getStringOfPerformGenres() {
     List<String> genres = new ArrayList<>();
@@ -135,6 +139,37 @@ public class Performance extends BaseTimeEntity {
       genres.add(genre.getGenre());
     }
     return genres;
+  }
+
+
+  public Performance updateInfo(PerformUpdateRequestDto updateRequest) {
+    this.title = updateRequest.getTitle();
+    this.location = updateRequest.getLocation();
+    this.address = updateRequest.getAddress();
+    this.startDate = updateRequest.getStartDate();
+    this.startTime = updateRequest.getStartTime();
+    this.performanceImg = new Image(updateRequest.getImgUrl());
+    this.description = updateRequest.getDescription();
+    return this;
+  }
+
+  /**
+   * PerformGenre -> String 으로 변환
+   */
+  private Set<String> getOriginalGenres() {
+    return this.performGenres.stream()
+        .map(PerformGenre::getGenre)
+        .collect(Collectors.toSet());
+  }
+
+  /**
+   * 수정하려는 장르의 Set 과 기존 장르의 Set 을 containsAll 메서드로 비교합니다.
+   *
+   * @param newGenres 새로운 장르 Set<String>
+   * @return 모두 포함한다면 true, 하나라도 중복되지 않는 값이 있다면 false.
+   */
+  public boolean isSame(Set<String> newGenres) {
+    return getOriginalGenres().containsAll(newGenres);
   }
 
 }

--- a/src/main/java/dnd/danverse/domain/performance/entity/Performance.java
+++ b/src/main/java/dnd/danverse/domain/performance/entity/Performance.java
@@ -141,7 +141,12 @@ public class Performance extends BaseTimeEntity {
     return genres;
   }
 
-
+  /**
+   * performGenre 를 제외한 performance 정보를 수정합니다.
+   *
+   * @param updateRequest 수정 요청 Dto.
+   * @return 수정된 Performance.
+   */
   public Performance updateInfo(PerformUpdateRequestDto updateRequest) {
     this.title = updateRequest.getTitle();
     this.location = updateRequest.getLocation();
@@ -156,7 +161,7 @@ public class Performance extends BaseTimeEntity {
   /**
    * PerformGenre -> String 으로 변환
    */
-  private Set<String> getOriginalGenres() {
+  private Set<String> toStringGenre() {
     return this.performGenres.stream()
         .map(PerformGenre::getGenre)
         .collect(Collectors.toSet());
@@ -169,7 +174,7 @@ public class Performance extends BaseTimeEntity {
    * @return 모두 포함한다면 true, 하나라도 중복되지 않는 값이 있다면 false.
    */
   public boolean isSame(Set<String> newGenres) {
-    return getOriginalGenres().containsAll(newGenres);
+    return toStringGenre().containsAll(newGenres);
   }
 
 }

--- a/src/main/java/dnd/danverse/domain/performance/entity/Performance.java
+++ b/src/main/java/dnd/danverse/domain/performance/entity/Performance.java
@@ -173,7 +173,7 @@ public class Performance extends BaseTimeEntity {
    * @param newGenres 새로운 장르 Set<String>
    * @return 모두 포함한다면 true, 하나라도 중복되지 않는 값이 있다면 false.
    */
-  public boolean isSame(Set<String> newGenres) {
+  public boolean containGenres(Set<String> newGenres) {
     return toStringGenre().containsAll(newGenres);
   }
 

--- a/src/main/java/dnd/danverse/domain/performance/exception/NotSameProfileException.java
+++ b/src/main/java/dnd/danverse/domain/performance/exception/NotSameProfileException.java
@@ -1,0 +1,13 @@
+package dnd.danverse.domain.performance.exception;
+
+import dnd.danverse.global.exception.BusinessException;
+import dnd.danverse.global.exception.ErrorCode;
+
+/**
+ * 글 작성자와 수정 요청 사용자가 동일하지 않으면 예외가 발생한다.
+ */
+public class NotSameProfileException extends BusinessException {
+  public NotSameProfileException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+}

--- a/src/main/java/dnd/danverse/domain/performance/service/PerformUpdateComplexService.java
+++ b/src/main/java/dnd/danverse/domain/performance/service/PerformUpdateComplexService.java
@@ -1,0 +1,97 @@
+package dnd.danverse.domain.performance.service;
+
+import dnd.danverse.domain.performance.dto.request.PerformUpdateRequestDto;
+import dnd.danverse.domain.performance.dto.response.PerformDetailResponse;
+import dnd.danverse.domain.performance.entity.Performance;
+import dnd.danverse.domain.performgenre.entity.PerformGenre;
+import dnd.danverse.domain.performgenre.service.PerformGenrePureService;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * 글 수정 복합 서비스.
+ */
+@Service
+@RequiredArgsConstructor
+public class PerformUpdateComplexService {
+
+  private final PerformWriterValidationService performWriterValidationService;
+  private final PerformancePureService performancePureService;
+  private final PerformGenrePureService performGenrePureService;
+
+  /**
+   * 1. 글 작성자와 수정을 요청하는 사용자와 동일한지 확인한다.
+   * 2. 수정 요청 dto에 따라 수정이 일어난다.
+   * 3-1. 기존의 장르 데이터와 요청하는 장르 데이터의 동일하면, 그대로 반환한다.
+   * 3-2. 기존의 장르 데이터와 요청하는 장르 데이터가 다르면, deleteAll과 saveAll을 한 후에 반환한다.
+   *
+   * @param updateRequest 수정 요청 Dto.
+   * @param memberId 사용자 Id.
+   * @return 공연 응답 Dto.
+   */
+  public PerformDetailResponse updatePerform(PerformUpdateRequestDto updateRequest, Long memberId) {
+
+    // <리펙토링 전>
+    // 공연 + 주최자 (validate)
+    // 멤버 (validate)
+    // 공연 + 주최자 + 장르 (장르 비교 위해)
+
+
+    // <리펙토링 다양한 방안>
+    // 2번
+    // 공연 + 주최자 + 장르 (추후 장르 비교를 위해) (validate) => fetch join
+    // 멤버 (validate)
+    // 장점 : 2번 나간다.
+    // 단점 : 공연 주최자랑 api 요청자가 다른 경우, 3번 fetch join 의미 없다. => 3번 조인으로 중복된 데이터 발생
+
+    // 3번
+    // 공연 -> 주최자 (프록시, 인식표)
+    // 멤버 (validate)
+    // 공연(더티) + 주최자(응닶) + 장르(업데이트 내역) => fetch join
+    // 장점 : 공연 주최자랑 api 요청자가 다른 경우, join 최소화
+    // 단점 : 쿼리 3번, 3개의 테이블 조인, 3개 조인으로 중복된 데이터 발생
+
+    // 3번
+    // 공연 + 주최자 (fetch join)
+    // 멤버
+    // 공연 => 장르 (lazy loading) => 조인 없이 1개의 테이블 대상으로 쿼리 날린다.
+    // 특징 : 모든 상황에 대해 중간 지점 (주최자 , api 요청자 맞는지 틀렸는지 상관없이)
+    // 장점 : 최대 2개 테이블 조인 (중복 된 데이터 발생 안함)
+    // 장점 : 장르에 대해서 추가적인 조인 없어
+
+    // <저울질>
+    // 1. 2번 사용 + 삭제 validate method 추가 생성
+    // 2. (3번 a,b 방법 중 택1) + 삭제 validate method 추가 생성
+    // 3. 2번 방법 다 사용 (x)
+
+    // 3번 b => 2번 => 3번 a
+
+
+    Performance performance = performWriterValidationService.isSameUser(updateRequest.getId(), memberId);
+
+    Performance newPerformance = performancePureService.updatePerform(performance, updateRequest);
+    if (newPerformance.isSame(updateRequest.getGenres())) {
+      return new PerformDetailResponse(newPerformance);
+    }
+    Set<PerformGenre> newGenres = stringToGenre(updateRequest, newPerformance);
+    performGenrePureService.deleteAndSaveAll(updateRequest.getId(), newGenres);
+    return new PerformDetailResponse(newPerformance, newGenres);
+  }
+
+  /**
+   * 기존의 요청 Dto 에서는 Set<String> 형태로 장르가 담겨있다.
+   * 그러나 실제 엔티티에서는 Set<PerformGenre>이기 때문에, 이를 변환한다.
+   * String -> PerformGenre
+   *
+   * @param updateRequest 요청 Dto.
+   * @param performance 장르를 바꾸려고 하는 공연 객체.
+   * @return Set<PerformGenre>
+   */
+  private Set<PerformGenre> stringToGenre(PerformUpdateRequestDto updateRequest, Performance performance) {
+    return updateRequest.getGenres().stream()
+        .map(genre -> new PerformGenre(genre, performance))
+        .collect(Collectors.toSet());
+  }
+}

--- a/src/main/java/dnd/danverse/domain/performance/service/PerformWriterValidationService.java
+++ b/src/main/java/dnd/danverse/domain/performance/service/PerformWriterValidationService.java
@@ -1,0 +1,42 @@
+package dnd.danverse.domain.performance.service;
+
+import static dnd.danverse.global.exception.ErrorCode.PERFORMANCE_NOT_WRITER;
+
+import dnd.danverse.domain.performance.entity.Performance;
+import dnd.danverse.domain.performance.exception.NotSameProfileException;
+import dnd.danverse.domain.profile.entity.Profile;
+import dnd.danverse.domain.profile.service.ProfilePureService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * 공연, 프로필 half 복합 서비스.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PerformWriterValidationService {
+
+  private final PerformancePureService performancePureService;
+  private final ProfilePureService profilePureService;
+
+  /**
+   * 공연 수정을 요청하는 사용자와 실제 작성자가 동일한 지 비교한다.
+   * 동일하지 않다면 예외처리를 한다.
+   *
+   * @param performId 공연 Id.
+   * @param memberId 수정 요청 사용자 Id.
+   * @return 수정하려는 Performance 객체.
+   */
+  public Performance isSameUser(Long performId, Long memberId) {
+    Performance performance = performancePureService.getPerformanceDetail(performId);
+    Profile writer = performance.getProfileHost();
+    Profile profile = profilePureService.retrieveProfile(memberId);
+    if (writer.isNotSame(profile)) {
+      throw new NotSameProfileException(PERFORMANCE_NOT_WRITER);
+    }
+    return performance;
+  }
+
+}

--- a/src/main/java/dnd/danverse/domain/performance/service/PerformWriterValidationService.java
+++ b/src/main/java/dnd/danverse/domain/performance/service/PerformWriterValidationService.java
@@ -9,6 +9,7 @@ import dnd.danverse.domain.profile.service.ProfilePureService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * 공연, 프로필 half 복합 서비스.
@@ -29,7 +30,8 @@ public class PerformWriterValidationService {
    * @param memberId 수정 요청 사용자 Id.
    * @return 수정하려는 Performance 객체.
    */
-  public Performance isSameUser(Long performId, Long memberId) {
+  @Transactional(readOnly = true)
+  public Performance validatePerformWriter(Long performId, Long memberId) {
     Performance performance = performancePureService.getPerformanceDetail(performId);
     Profile writer = performance.getProfileHost();
     Profile profile = profilePureService.retrieveProfile(memberId);

--- a/src/main/java/dnd/danverse/domain/performance/service/PerformancePureService.java
+++ b/src/main/java/dnd/danverse/domain/performance/service/PerformancePureService.java
@@ -2,6 +2,7 @@ package dnd.danverse.domain.performance.service;
 
 import static dnd.danverse.global.exception.ErrorCode.PERFORMANCE_NOT_FOUND;
 
+import dnd.danverse.domain.performance.dto.request.PerformUpdateRequestDto;
 import dnd.danverse.domain.performance.dto.response.ImminentPerformsDto;
 import dnd.danverse.domain.performance.entity.Performance;
 import dnd.danverse.domain.performance.exception.PerformanceNotFoundException;
@@ -10,6 +11,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Service
 @RequiredArgsConstructor
+@Slf4j
 @Transactional(readOnly = true)
 public class PerformancePureService {
 
@@ -39,6 +42,7 @@ public class PerformancePureService {
 
   @Transactional(readOnly = true)
   public Performance getPerformanceDetail(Long performId) {
+    log.info("performance와 작성자의 profile을 fetch join 하여 찾습니다. performId: {}", performId);
     return performanceRepository.findPerformanceWithProfile(performId)
         .orElseThrow(() -> new PerformanceNotFoundException(PERFORMANCE_NOT_FOUND));
   }
@@ -48,5 +52,17 @@ public class PerformancePureService {
     return performanceRepository.save(performance);
   }
 
+  /**
+   * 공연 정보를 updateRequestDto 대로 수정합니다.
+   *
+   * @param performance 수정하려는 공연.
+   * @param request 수정 요청 Dto.
+   * @return 요청 Dto 대로 수정합니다.
+   */
+  @Transactional
+  public Performance updatePerform(Performance performance, PerformUpdateRequestDto request) {
+    log.info("요청 dto로 수정합니다.");
+    return performance.updateInfo(request);
+  }
 
 }

--- a/src/main/java/dnd/danverse/domain/performgenre/entity/PerformGenre.java
+++ b/src/main/java/dnd/danverse/domain/performgenre/entity/PerformGenre.java
@@ -19,7 +19,7 @@ import org.hibernate.annotations.OnDeleteAction;
 import org.hibernate.annotations.Parameter;
 
 /**
- * 공연 - 장르, 중간 테이블 Entity
+ * 공연 - 장르, 중간 테이블 Entity.
  */
 @Entity
 @NoArgsConstructor
@@ -60,18 +60,26 @@ public class PerformGenre extends BaseTimeEntity {
 
   /**
    * 생성자.
+   *
    * @param genre 장르
    */
   public PerformGenre(String genre) {
     this.genre = genre;
   }
 
+  public PerformGenre(String genre, Performance performance) {
+    this.genre = genre;
+    this.performance = performance;
+  }
+
   /**
    * 양방향 연관관계 편의 메소드.
-   * @param performance 외래키로 들어갈 공연 객체
+   *
+   * @param performance 외래키로 들어갈 공연 객체.
    */
   public void addPerform(Performance performance) {
     this.performance = performance;
     performance.getPerformGenres().add(this);
   }
+
 }

--- a/src/main/java/dnd/danverse/domain/performgenre/repository/PerformGenreRepository.java
+++ b/src/main/java/dnd/danverse/domain/performgenre/repository/PerformGenreRepository.java
@@ -2,9 +2,15 @@ package dnd.danverse.domain.performgenre.repository;
 
 import dnd.danverse.domain.performgenre.entity.PerformGenre;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PerformGenreRepository extends JpaRepository<PerformGenre, Long> {
+  @Modifying
+  @Query("delete from PerformGenre pg where pg.performance.id = :performId")
+  void deleteByPerformId(@Param("performId") Long performId);
 
 }

--- a/src/main/java/dnd/danverse/domain/performgenre/service/PerformGenrePureService.java
+++ b/src/main/java/dnd/danverse/domain/performgenre/service/PerformGenrePureService.java
@@ -1,0 +1,37 @@
+package dnd.danverse.domain.performgenre.service;
+
+import dnd.danverse.domain.performgenre.entity.PerformGenre;
+import dnd.danverse.domain.performgenre.repository.PerformGenreRepository;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 공연 장르 순수 서비스.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PerformGenrePureService {
+
+  private final PerformGenreRepository performGenreRepository;
+
+  /**
+   * 이전의 공연 genre 데이터를 모두 삭제한 후, 다시 새로운 genre 데이터를 saveAll 합니다.
+   *
+   * @param performanceId 수정하려는 공연 Id.
+   * @param newGenres 새로운 genre 데이터.
+   */
+  @Transactional
+  public void deleteAndSaveAll(Long performanceId, Set<PerformGenre> newGenres) {
+    // 이전 PerformGenre 데이터를 모두 삭제합니다.
+    log.info("이전 공연의 genre 데이터를 모두 삭제합니다. 공연 Id : {}", performanceId);
+    performGenreRepository.deleteByPerformId(performanceId);
+
+    log.info("새로운 genre 데이터를 저장합니다.");
+    performGenreRepository.saveAll(newGenres);
+  }
+
+}

--- a/src/main/java/dnd/danverse/global/exception/ErrorCode.java
+++ b/src/main/java/dnd/danverse/global/exception/ErrorCode.java
@@ -33,6 +33,7 @@ public enum ErrorCode {
   // 공연
   PERFORMANCE_NOT_FOUND(HttpStatus.NOT_FOUND, "PF001", "존재하지 않는 공연 정보입니다."),
 
+  PERFORMANCE_NOT_WRITER(HttpStatus.FORBIDDEN, "PF002", "작성자 외에 접근 권한이 없습니다."),
 
   // 회원 member
   MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "M001", "존재하지 않는 회원입니다."),

--- a/src/main/java/dnd/danverse/global/security/config/SecurityConfig.java
+++ b/src/main/java/dnd/danverse/global/security/config/SecurityConfig.java
@@ -50,7 +50,7 @@ public class SecurityConfig {
         .antMatchers(HttpMethod.DELETE, "/api/v1/events/{eventId}/cancel-apply", "/api/v1/events/{eventId}")
           .hasAuthority(userRole)
         .antMatchers(HttpMethod.GET, "/api/v1/events/{eventId}/applicants").hasAuthority(userRole)
-        .antMatchers(HttpMethod.PATCH, "/api/v1/events/{eventId}/accept", "/api/v1/events/deadline")
+        .antMatchers(HttpMethod.PATCH, "/api/v1/events/{eventId}/accept", "/api/v1/events/deadline", "/api/v1/performances")
           .hasAuthority(userRole)
         .anyRequest().permitAll();
 


### PR DESCRIPTION
### ✒️ 관련 이슈번호

- Close #101 

## 🔑 Key Changes

1. 공연 정보 컨트롤러 메서드 구현
2. 장르 변경이 생겼을 경우 responseDto 생성자 구현
3. List<PerformGenre>에서 Set<PerformGenre>로 변경
4. 글 수정 관련 순수, 복합 서비스 구현
5. 글 수정 관련 에러 코드 정의
6. securityConfig에 정보 수정 url 추가

## 📢 To Reviewers

- None