### PR TITLE
[Feat] : 공연 정보 삭제 기능 구현

### DIFF
--- a/src/main/java/dnd/danverse/domain/performance/controller/PerformanceController.java
+++ b/src/main/java/dnd/danverse/domain/performance/controller/PerformanceController.java
@@ -9,14 +9,17 @@ import dnd.danverse.domain.performance.dto.response.PageDto;
 import dnd.danverse.domain.performance.dto.response.PerformDetailResponse;
 import dnd.danverse.domain.performance.dto.response.PerformInfoResponse;
 import dnd.danverse.domain.performance.dto.response.PerformListResponse;
+import dnd.danverse.domain.performance.service.PerformDeleteService;
 import dnd.danverse.domain.performance.service.PerformFilterService;
 import dnd.danverse.domain.performance.service.PerformSaveComplexService;
 import dnd.danverse.domain.performance.service.PerformSearchComplexService;
 import dnd.danverse.domain.performance.service.PerformUpdateComplexService;
 import dnd.danverse.domain.performance.service.PerformancePureService;
 import dnd.danverse.global.response.DataResponse;
+import dnd.danverse.global.response.MessageResponse;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +27,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -47,6 +51,7 @@ public class PerformanceController {
   private final PerformSearchComplexService performSearchComplexService;
   private final PerformSaveComplexService performSaveComplexService;
   private final PerformUpdateComplexService performUpdateComplexService;
+  private final PerformDeleteService performDeleteService;
 
   /**
    * 공연이 임박한 공연을 조회할 수 있다. 오늘 날짜 기준으로, 최근 공연 4개를 조회할 수 있다.
@@ -136,10 +141,29 @@ public class PerformanceController {
   @ApiOperation(value = "공연 글 수정", notes = "작성자에 한하여 글을 수정할 수 있다.")
   @ApiImplicitParam(name = "Authorization", value = "Bearer access_token (서버에서 발급한 access_token)",
       required = true, dataType = "string", paramType = "header")
-  public ResponseEntity<DataResponse<PerformDetailResponse>> updatePerform(@RequestBody PerformUpdateRequestDto updateRequest
-      , @AuthenticationPrincipal SessionUser sessionUser) {
+  public ResponseEntity<DataResponse<PerformDetailResponse>> updatePerform(@RequestBody PerformUpdateRequestDto updateRequest, @AuthenticationPrincipal SessionUser sessionUser) {
     PerformDetailResponse response = performUpdateComplexService.updatePerform(updateRequest, sessionUser.getId());
     return new ResponseEntity<>(DataResponse.of(HttpStatus.OK, "공연 수정 성공", response), HttpStatus.OK);
+  }
+
+  /**
+   * 공연 글 삭제.
+   *
+   * @param performId 삭제하려는 공연 고유 Id.
+   * @param sessionUser 삭제 요청 사용자 고유 Id.
+   * @return 글 삭제에 성공하면 200 상태코드와 함께 메시지를 반환.
+   */
+  @DeleteMapping("/{performId}")
+  @ApiOperation(value = "공연 글 삭제", notes = "작성자에 한하여 글을 삭제할 수 있다.")
+  @ApiImplicitParams({
+      @ApiImplicitParam(name = "performId", value = "공연 고유 ID", required = true),
+      @ApiImplicitParam(name = "Authorization", value = "Bearer access_token (서버에서 발급한 access_token)",
+          required = true, dataType = "string", paramType = "header")
+  })
+  public ResponseEntity<MessageResponse> deletePerform(@PathVariable("performId") Long performId,
+      @AuthenticationPrincipal SessionUser sessionUser) {
+    performDeleteService.deletePerform(performId, sessionUser.getId());
+    return new ResponseEntity<>(MessageResponse.of(HttpStatus.OK, "공연 삭제 성공"), HttpStatus.OK);
   }
 
 }

--- a/src/main/java/dnd/danverse/domain/performance/service/PerformDeleteService.java
+++ b/src/main/java/dnd/danverse/domain/performance/service/PerformDeleteService.java
@@ -1,0 +1,30 @@
+package dnd.danverse.domain.performance.service;
+
+import dnd.danverse.domain.performance.entity.Performance;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * 공연 삭제 복합 서비스.
+ */
+@Service
+@RequiredArgsConstructor
+public class PerformDeleteService {
+
+  private final PerformancePureService performancePureService;
+  private final PerformWriterValidationService performWriterValidationService;
+
+  /**
+   * 작성자와 삭제 요청 사용자가 동일한지 확인합니다.
+   * 동일하다면, 삭제가 이뤄집니다.
+   * 동일하지 않다면, 예외 처리를 해줍니다.
+   *
+   * @param performId 삭제하려는 공연 고유 Id.
+   * @param memberId 삭제 요청 사용자 고유 Id.
+   */
+  public void deletePerform(Long performId, Long memberId) {
+    performWriterValidationService.validatePerformWriter(performId, memberId);
+    Performance performance = performancePureService.getPerformance(performId);
+    performancePureService.deletePerform(performance);
+  }
+}

--- a/src/main/java/dnd/danverse/domain/performance/service/PerformancePureService.java
+++ b/src/main/java/dnd/danverse/domain/performance/service/PerformancePureService.java
@@ -69,6 +69,7 @@ public class PerformancePureService {
 
   /**
    * Performance 만 찾기 위해 사용한다.
+   *
    * @param performId Performance 의 id
    * @return Performance
    */
@@ -78,4 +79,16 @@ public class PerformancePureService {
     return performanceRepository.findById(performId)
         .orElseThrow(() -> new PerformanceNotFoundException(PERFORMANCE_NOT_FOUND));
   }
+
+  /**
+   * 공연 정보를 삭제합니다.
+   *
+   * @param performance 삭제하려는 공연 정보.
+   */
+  @Transactional
+  public void deletePerform(Performance performance) {
+    log.info("performId가 {}인 공연글을 삭제합니다.", performance.getId());
+    performanceRepository.delete(performance);
+  }
+
 }

--- a/src/main/java/dnd/danverse/global/security/config/SecurityConfig.java
+++ b/src/main/java/dnd/danverse/global/security/config/SecurityConfig.java
@@ -48,7 +48,7 @@ public class SecurityConfig {
             "/api/v1/events/image", "/api/v1/performances/image", "/api/v1/profiles/image", "/api/v1/performances",
             "/api/v1/performances/{performId}/reviews")
           .hasAuthority(userRole)
-        .antMatchers(HttpMethod.DELETE, "/api/v1/events/{eventId}/cancel-apply", "/api/v1/events/{eventId}")
+        .antMatchers(HttpMethod.DELETE, "/api/v1/events/{eventId}/cancel-apply", "/api/v1/events/{eventId}", "/api/v1/performances/{eventId}")
           .hasAuthority(userRole)
         .antMatchers(HttpMethod.GET, "/api/v1/events/{eventId}/applicants").hasAuthority(userRole)
         .antMatchers(HttpMethod.PATCH, "/api/v1/events/{eventId}/accept", "/api/v1/events/deadline", "/api/v1/performances")


### PR DESCRIPTION
### ✒️ 관련 이슈번호

- Close #125 

## 🔑 Key Changes

1. 공연 정보 삭제 컨트롤러 구현
2. 공연 삭제 기능 관련 순수, 복합 서비스 구현
3. securityConfig에 삭제 url 추가
4. Swagger 매핑

## 📢 To Reviewers

- None