### PR TITLE
[Feat] : 공연에 대한 후기 조회 기능 구현

### DIFF
--- a/src/main/java/dnd/danverse/domain/profile/repository/ProfileRepository.java
+++ b/src/main/java/dnd/danverse/domain/profile/repository/ProfileRepository.java
@@ -3,7 +3,6 @@ package dnd.danverse.domain.profile.repository;
 import dnd.danverse.domain.profile.entity.Profile;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -21,6 +20,4 @@ public interface ProfileRepository extends JpaRepository<Profile, Long> {
   @Query("SELECT p FROM Profile p")
   List<Profile> findAllProfiles();
 
-  @Query("SELECT p FROM Profile p WHERE p.member.id IN :memberIds")
-  List<Profile> findAllProfilesWithMemberIds(@Param("memberIds") Set<Long> memberIds);
 }

--- a/src/main/java/dnd/danverse/domain/profile/repository/ProfileRepository.java
+++ b/src/main/java/dnd/danverse/domain/profile/repository/ProfileRepository.java
@@ -1,8 +1,9 @@
-package dnd.danverse.domain.profile;
+package dnd.danverse.domain.profile.repository;
 
 import dnd.danverse.domain.profile.entity.Profile;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -19,4 +20,7 @@ public interface ProfileRepository extends JpaRepository<Profile, Long> {
 
   @Query("SELECT p FROM Profile p")
   List<Profile> findAllProfiles();
+
+  @Query("SELECT p FROM Profile p WHERE p.member.id IN :memberIds")
+  List<Profile> findAllProfilesWithMemberIds(@Param("memberIds") Set<Long> memberIds);
 }

--- a/src/main/java/dnd/danverse/domain/profile/service/ProfilePureService.java
+++ b/src/main/java/dnd/danverse/domain/profile/service/ProfilePureService.java
@@ -3,7 +3,7 @@ package dnd.danverse.domain.profile.service;
 import static dnd.danverse.global.exception.ErrorCode.PROFILE_NOT_FOUND;
 
 import dnd.danverse.domain.profile.exception.NoProfileException;
-import dnd.danverse.domain.profile.ProfileRepository;
+import dnd.danverse.domain.profile.repository.ProfileRepository;
 import dnd.danverse.domain.profile.entity.Profile;
 import java.util.List;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/dnd/danverse/domain/review/controller/ReviewController.java
+++ b/src/main/java/dnd/danverse/domain/review/controller/ReviewController.java
@@ -4,20 +4,23 @@ import dnd.danverse.domain.jwt.service.SessionUser;
 import dnd.danverse.domain.review.dto.request.ReviewContentDto;
 import dnd.danverse.domain.review.dto.response.ReviewInfoDto;
 import dnd.danverse.domain.review.service.ReviewSaveComplexService;
+import dnd.danverse.domain.review.service.ReviewsSearchComplexService;
 import dnd.danverse.global.response.DataResponse;
+import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import springfox.documentation.annotations.ApiIgnore;
 
 /**
  * 후기 컨트롤러.
@@ -25,10 +28,11 @@ import springfox.documentation.annotations.ApiIgnore;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/performances")
-@ApiIgnore
+@Api(tags = "ReviewController : 공연 후기 관련 API")
 public class ReviewController {
 
   private final ReviewSaveComplexService reviewSaveComplexService;
+  private final ReviewsSearchComplexService reviewsSearchComplexService;
 
   /**
    * 후기를 저장한다.
@@ -44,13 +48,22 @@ public class ReviewController {
           required = true, dataType = "string", paramType = "header"),
       @ApiImplicitParam(name = "performId", value = "공연 고유 ID", required = true, dataType = "long", paramType = "path")
   })
-  public ResponseEntity<DataResponse<ReviewInfoDto>> createReview(
+  public ResponseEntity<DataResponse<List<ReviewInfoDto>>> createReview(
       @PathVariable("performId") Long performId, @RequestBody ReviewContentDto contentDto,
       @AuthenticationPrincipal SessionUser user) {
-    ReviewInfoDto reviewInfoDto = reviewSaveComplexService.saveReview(contentDto, performId, user.getId());
+    List<ReviewInfoDto> allReviews = reviewSaveComplexService.saveReview(contentDto, performId, user.getId());
     return new ResponseEntity<>(
-        DataResponse.of(HttpStatus.CREATED, "리뷰가 성공적으로 등록되었습니다.", reviewInfoDto),
+        DataResponse.of(HttpStatus.CREATED, "리뷰가 성공적으로 등록되었습니다.", allReviews),
         HttpStatus.CREATED);
+  }
+
+  @GetMapping("/{performId}/reviews")
+  @ApiOperation(value = "공연에 대한 모든 후기를 조회한다.", notes = "공연에 대한 모든 후기를 조회한다.")
+  @ApiImplicitParam(name = "performId", value = "공연 고유 ID", required = true, dataType = "long", paramType = "path")
+  public ResponseEntity<DataResponse<List<ReviewInfoDto>>> findAllReviews(@PathVariable("performId") Long performId) {
+    List<ReviewInfoDto> allReviews = reviewsSearchComplexService.findAllReviews(performId);
+    return new ResponseEntity<>(DataResponse.of(HttpStatus.OK, "리뷰 조회에 성공했습니다.", allReviews),
+        HttpStatus.OK);
   }
 
 

--- a/src/main/java/dnd/danverse/domain/review/dto/request/ReviewContentDto.java
+++ b/src/main/java/dnd/danverse/domain/review/dto/request/ReviewContentDto.java
@@ -18,7 +18,7 @@ public class ReviewContentDto {
    * 리뷰 내용
    */
   @ApiModelProperty(value = "후기 내용")
-  private String content;
+  private String review;
 
 
   /**
@@ -31,7 +31,7 @@ public class ReviewContentDto {
     return Review.builder()
         .member(member)
         .performance(performance)
-        .content(content)
+        .content(review)
         .build();
   }
 }

--- a/src/main/java/dnd/danverse/domain/review/dto/response/ReviewInfoDto.java
+++ b/src/main/java/dnd/danverse/domain/review/dto/response/ReviewInfoDto.java
@@ -47,6 +47,7 @@ public class ReviewInfoDto {
   /**
    * 후기 작성자 정보를 담는다.
    */
+  @Getter
   static class Writer {
 
     /**
@@ -98,5 +99,38 @@ public class ReviewInfoDto {
    */
   private boolean hasProfile(Member member) {
     return member.getProfile() != null;
+  }
+
+
+  /**
+   * 해당 생성자는 공연 후기 조회 시, 응답에 필요한 데이터만을 조회하기 위해 만들었다.
+   * @param reviewId 후기 ID
+   * @param content 후기 내용
+   * @param createdDate 후기 작성 시간
+   * @param memberId 후기 작성자 ID
+   * @param memberName 후기 작성자 이름
+   * @param profileId 후기 작성자 프로필 ID
+   * @param profileName 후기 작성자 프로필 이름
+   */
+  public ReviewInfoDto(Long reviewId, String content, LocalDateTime createdDate,
+      Long memberId, String memberName, Long profileId, String profileName) {
+    this.reviewId = reviewId;
+    this.content = content;
+    this.createdDate = createdDate;
+    if (hasProfile(profileId)) {
+      this.writer = new Writer(profileId, profileName);
+    } else {
+      this.writer = new Writer(memberId, memberName);
+    }
+    this.hasProfile = profileId != null;
+  }
+
+  /**
+   * profileId 가 null 이 아닌지 여부를 반환한다.
+   * @param profileId 후기 작성자 프로필 ID
+   * @return profileId 가 null 이 아닌지 여부
+   */
+  private static boolean hasProfile(Long profileId) {
+    return profileId != null;
   }
 }

--- a/src/main/java/dnd/danverse/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/dnd/danverse/domain/review/repository/ReviewRepository.java
@@ -1,7 +1,11 @@
 package dnd.danverse.domain.review.repository;
 
+import dnd.danverse.domain.review.dto.response.ReviewInfoDto;
 import dnd.danverse.domain.review.entity.Review;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 /**
@@ -9,5 +13,8 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, Long> {
-
+  @Query("select new dnd.danverse.domain.review.dto.response."
+      + "ReviewInfoDto(r.id,r.content, r.createdAt, m.id,m.name, p.id,p.profileName)"
+      + " from Review r join r.member m left join m.profile p where r.performance.id = :performId")
+  List<ReviewInfoDto> findAllReviewsWithWriter(@Param("performId") Long performId);
 }

--- a/src/main/java/dnd/danverse/domain/review/service/ReviewPureService.java
+++ b/src/main/java/dnd/danverse/domain/review/service/ReviewPureService.java
@@ -1,7 +1,9 @@
 package dnd.danverse.domain.review.service;
 
+import dnd.danverse.domain.review.dto.response.ReviewInfoDto;
 import dnd.danverse.domain.review.entity.Review;
 import dnd.danverse.domain.review.repository.ReviewRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -26,5 +28,20 @@ public class ReviewPureService {
   public Review saveReview(Review review) {
     log.info("Review 를 저장한다. 내용 : {} ", review.getContent());
     return reviewRepository.save(review);
+  }
+
+  /**
+   * 공연에 대한 모든 리뷰를 조회한다.
+   * Review 와 Member 는 fetch join,
+   * Member 와 Profile 은 left join fetch 를 시도하려 했지만,
+   * 응답에 필요한 데이터에 비해, 너무 많은 컬럼을 조회하게 되어, 성능이 떨어지는 문제가 발생했다.
+   * 따라서, 별로의 Dto 를 만들어, 응답에 필요한 데이터만을 조회하도록 했다.
+   * @param performId 공연 ID
+   * @return 공연 리뷰 리스트
+   */
+  @Transactional(readOnly = true)
+  public List<ReviewInfoDto> findAllReviewsWithWriter(Long performId) {
+    log.info("dto 로 응답, Review 와 Member 를  join , Member 와 Profile left  join 조회한다. 공연 ID : {} ", performId);
+    return reviewRepository.findAllReviewsWithWriter(performId);
   }
 }

--- a/src/main/java/dnd/danverse/domain/review/service/ReviewSaveComplexService.java
+++ b/src/main/java/dnd/danverse/domain/review/service/ReviewSaveComplexService.java
@@ -7,6 +7,7 @@ import dnd.danverse.domain.performance.service.PerformancePureService;
 import dnd.danverse.domain.review.dto.request.ReviewContentDto;
 import dnd.danverse.domain.review.dto.response.ReviewInfoDto;
 import dnd.danverse.domain.review.entity.Review;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -31,14 +32,13 @@ public class ReviewSaveComplexService {
    * @param memberId 후기 작성자 Id
    * @return 후기 정보
    */
-  public ReviewInfoDto saveReview(ReviewContentDto contentDto, Long performId, Long memberId) {
+  public List<ReviewInfoDto> saveReview(ReviewContentDto contentDto, Long performId, Long memberId) {
     // member Id를 통해서 우선 프로필이 있는지 확인한다.
     Member member = memberPureService.findMemberWithProfile(memberId);
     Performance perform = performancePureService.getPerformance(performId);
     Review review = contentDto.toReview(member, perform);
-    Review savedReview = reviewPureService.saveReview(review);
+    reviewPureService.saveReview(review);
 
-    // 프로필이 있으면 응답 이름에 프로필 이름을 넣어서 리뷰를 응답한다.
-    return new ReviewInfoDto(savedReview, member);
+    return reviewPureService.findAllReviewsWithWriter(perform.getId());
   }
 }

--- a/src/main/java/dnd/danverse/domain/review/service/ReviewsSearchComplexService.java
+++ b/src/main/java/dnd/danverse/domain/review/service/ReviewsSearchComplexService.java
@@ -1,0 +1,28 @@
+package dnd.danverse.domain.review.service;
+
+import dnd.danverse.domain.review.dto.response.ReviewInfoDto;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * 공연 후기 전체 조회 복합 Service
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ReviewsSearchComplexService {
+
+  private final ReviewPureService reviewPureService;
+
+  /**
+   * 모든 리뷰를 조회한다.
+   *
+   * @param performId 공연 ID
+   * @return ReviewInfoDto 리스트
+   */
+  public List<ReviewInfoDto> findAllReviews(Long performId) {
+    return reviewPureService.findAllReviewsWithWriter(performId);
+  }
+}

--- a/src/test/java/dnd/danverse/domain/performance/repository/PerformanceRepositoryTest.java
+++ b/src/test/java/dnd/danverse/domain/performance/repository/PerformanceRepositoryTest.java
@@ -10,7 +10,7 @@ import dnd.danverse.domain.oauth.info.OAuth2Provider;
 import dnd.danverse.domain.performance.entity.Performance;
 import dnd.danverse.domain.performgenre.repository.PerformGenreRepository;
 import dnd.danverse.domain.performgenre.entity.PerformGenre;
-import dnd.danverse.domain.profile.ProfileRepository;
+import dnd.danverse.domain.profile.repository.ProfileRepository;
 import dnd.danverse.domain.profile.entity.OpenChat;
 import dnd.danverse.domain.profile.entity.Portfolio;
 import dnd.danverse.domain.profile.entity.Profile;


### PR DESCRIPTION
### ✒️ 관련 이슈번호

- Close #131 

## 🔑 Key Changes

1. 후기 등록 시, 응답 값에 save 했던 후기 반환 -> 해당 공연의 전체 후기 목록으로 응답 하도록 수정
2. 공연에 대한 전체 후기 조회 기능 구현
3. 응답을 위한 데이터 join 시 필요 없는 데이터까지 select 하게 되어, DTO로 조회할 수 있도록 구현
4. 후기 조회 시, 프로필이 있으면 프로필 이름 응답, 없으면 구글 이름 응답

## 📢 To Reviewers

- None