### PR TITLE
[Feat] : 프로필 상세 조회 기능 구현

### DIFF
--- a/src/main/java/dnd/danverse/domain/profile/controller/ProfileController.java
+++ b/src/main/java/dnd/danverse/domain/profile/controller/ProfileController.java
@@ -1,6 +1,8 @@
 package dnd.danverse.domain.profile.controller;
 
 import dnd.danverse.domain.profile.dto.response.ProfileHomeDto;
+import dnd.danverse.domain.profile.dto.response.ProfileWithGenreDto;
+import dnd.danverse.domain.profile.service.ProfileDetailService;
 import dnd.danverse.domain.profile.service.ProfileSearchService;
 import dnd.danverse.global.response.DataResponse;
 import io.swagger.annotations.Api;
@@ -11,6 +13,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 
@@ -24,6 +27,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class ProfileController {
 
   private final ProfileSearchService profileSearchService;
+  private final ProfileDetailService profileDetailService;
 
   /**
    * 서비스 사용자는 실제 사용자의 프로필 6개를 랜덤으로 조회할 수 있습니다.
@@ -35,6 +39,16 @@ public class ProfileController {
   public ResponseEntity<DataResponse<List<ProfileHomeDto>>> searchProfileForHome() {
     List<ProfileHomeDto> profileHomes = profileSearchService.searchProfileForHome();
     return new ResponseEntity<>(DataResponse.of(HttpStatus.OK, "프로필 6개 랜덤 조회 성공", profileHomes), HttpStatus.OK);
+  }
+
+  /**
+   * 서비스 사용자는 다른 사용자의 프로필을 조회할 수 있습니다.
+   */
+  @GetMapping("/{profileId}")
+  @ApiOperation(value = "프로필 상세 조회", notes = "다른 사용자의 프로필 상세 조회")
+  public ResponseEntity<DataResponse<ProfileWithGenreDto>> getProfile(@PathVariable("profileId") Long profileId) {
+    ProfileWithGenreDto profileWithGenreDto = profileDetailService.getProfile(profileId);
+    return new ResponseEntity<>(DataResponse.of(HttpStatus.OK, "프로필 상세 조회 성공", profileWithGenreDto), HttpStatus.OK);
   }
 
 

--- a/src/main/java/dnd/danverse/domain/profile/dto/response/ProfileWithGenreDto.java
+++ b/src/main/java/dnd/danverse/domain/profile/dto/response/ProfileWithGenreDto.java
@@ -1,0 +1,64 @@
+package dnd.danverse.domain.profile.dto.response;
+
+import dnd.danverse.domain.profile.entity.Portfolio;
+import dnd.danverse.domain.profile.entity.Profile;
+import io.swagger.annotations.ApiModelProperty;
+import java.time.LocalDate;
+import java.util.Set;
+import lombok.Getter;
+
+/**
+ * 프로필 상세 조회 정보를 담은 Dto.
+ * - 프로필 고유 id
+ * - 프로필 이름
+ * - 프로필 이미지 url
+ * - 프로필 활동지역
+ * - 프로필 장르
+ * - 프로필 커리어 시작 날짜
+ * - 프로필 상세설명
+ * - 오픈 채팅 url
+ * - 포트폴리오 url(유튜브, 인스타, 트위터)
+ */
+@Getter
+public class ProfileWithGenreDto {
+
+  @ApiModelProperty(name = "프로필의 고유 Id")
+  private final Long id;
+
+  @ApiModelProperty(name = "프로필 이름")
+  private final String profileName;
+
+  @ApiModelProperty(name = "프로필 이미지 url")
+  private final String imgUrl;
+
+  @ApiModelProperty(name = "프로필 활동 지역")
+  private final String location;
+
+  @ApiModelProperty(name = "프로필 관심 장르")
+  private final Set<String> genres;
+
+  @ApiModelProperty(name = "커리어 시작 날짜")
+  private final LocalDate startDate;
+
+  @ApiModelProperty(name = "프로필 상세 설명")
+  private final String description;
+
+  @ApiModelProperty(name = "프로필 오픈채팅 url")
+  private final String openChatUrl;
+
+  @ApiModelProperty(name = "프로필의 포트폴리오 url")
+  private final Portfolio portfolio;
+
+
+  public ProfileWithGenreDto(Profile profile) {
+    this.id = profile.getId();
+    this.profileName = profile.getProfileName();
+    this.imgUrl = profile.getProfileImg().getImageUrl();
+    this.location = profile.getLocation();
+    this.genres = profile.toStringProfileGenre();
+    this.startDate = profile.getCareerStartDay();
+    this.description = profile.getDescription();
+    this.openChatUrl = profile.getOpenChatUrl().getOpenChatUrl();
+    this.portfolio = profile.getPortfolioUrl();
+  }
+}

--- a/src/main/java/dnd/danverse/domain/profile/entity/Profile.java
+++ b/src/main/java/dnd/danverse/domain/profile/entity/Profile.java
@@ -12,6 +12,7 @@ import java.time.LocalDate;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
@@ -153,6 +154,17 @@ public class Profile extends BaseTimeEntity {
     if (this.profileType != recruitType) {
       throw new EventNotAvailableException(EVENT_TYPE_NOT_MATCH);
     }
+  }
+
+  /**
+   * 프로필 장르를 String 타입으로 변환한다.
+   *
+   * @return String 타입의 Set 반환
+   */
+  public Set<String> toStringProfileGenre() {
+    return this.profileGenres.stream()
+        .map(ProfileGenre::getGenre)
+        .collect(Collectors.toSet());
   }
 
   public boolean isNotSame(Profile stranger) {

--- a/src/main/java/dnd/danverse/domain/profile/repository/ProfileRepository.java
+++ b/src/main/java/dnd/danverse/domain/profile/repository/ProfileRepository.java
@@ -20,4 +20,7 @@ public interface ProfileRepository extends JpaRepository<Profile, Long> {
   @Query("SELECT p FROM Profile p")
   List<Profile> findAllProfiles();
 
+  @Query("select p from Profile p join fetch p.profileGenres where p.id = :profileId")
+  Optional<Profile> findProfileWithGenreById(@Param("profileId") Long profileId);
+
 }

--- a/src/main/java/dnd/danverse/domain/profile/service/ProfileDetailService.java
+++ b/src/main/java/dnd/danverse/domain/profile/service/ProfileDetailService.java
@@ -1,0 +1,28 @@
+package dnd.danverse.domain.profile.service;
+
+import dnd.danverse.domain.profile.dto.response.ProfileWithGenreDto;
+import dnd.danverse.domain.profile.entity.Profile;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * 프로필 상세 조회 복합 서비스.
+ */
+@Service
+@RequiredArgsConstructor
+public class ProfileDetailService {
+
+  private final ProfilePureService profilePureService;
+
+  /**
+   * 프로필 순수 서비스에서 프로필 아이디를 통해서 프로필의 상세 정보를 가져옵니다.
+   *
+   * @param profileId 조회하려고 하는 profileId.
+   * @return profile 과 genre 를 함께 반환하는 응답 Dto.
+   */
+  public ProfileWithGenreDto getProfile(Long profileId) {
+    Profile profile = profilePureService.getProfileDetail(profileId);
+    return new ProfileWithGenreDto(profile);
+  }
+
+}

--- a/src/main/java/dnd/danverse/domain/profile/service/ProfilePureService.java
+++ b/src/main/java/dnd/danverse/domain/profile/service/ProfilePureService.java
@@ -2,9 +2,9 @@ package dnd.danverse.domain.profile.service;
 
 import static dnd.danverse.global.exception.ErrorCode.PROFILE_NOT_FOUND;
 
+import dnd.danverse.domain.profile.entity.Profile;
 import dnd.danverse.domain.profile.exception.NoProfileException;
 import dnd.danverse.domain.profile.repository.ProfileRepository;
-import dnd.danverse.domain.profile.entity.Profile;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * Profile Entity 에 대한 순수 Service
+ * Profile Entity 에 대한 순수 Service.
  */
 @Service
 @RequiredArgsConstructor
@@ -24,6 +24,7 @@ public class ProfilePureService {
   /**
    * 프로필 조회
    * 프로필이 존재하지 않으면 예외를 발생시킨다.
+   *
    * @param memberId 사용자 (member 고유 DB ID)
    * @return 프로필
    */
@@ -35,11 +36,27 @@ public class ProfilePureService {
   }
 
   /**
-   * 모든 프로필 조회
+   * 모든 프로필 조회.
+   *
    * @return 모든 프로필
    */
   @Transactional(readOnly = true)
   public List<Profile> searchProfileForHome() {
     return profileRepository.findAllProfiles();
+  }
+
+  /**
+   * 프로필을 상세 조회합니다.
+   * 프로필과 프로필 장르를 fetch join 하여 profile 을 반환합니다.
+   * 요청한 profile Id 에 해당하는 프로필이 없다면 예외로 처리합니다.
+   *
+   * @param profileId 조회하려고 하는 profile 고유 Id.
+   * @return Profile.
+   */
+  @Transactional(readOnly = true)
+  public Profile getProfileDetail(Long profileId) {
+    log.info("profileId: {}를 통해서 profile 과 profileGenre 를 fetch join 하여 찾습니다.", profileId);
+    return profileRepository.findProfileWithGenreById(profileId)
+        .orElseThrow(() -> new NoProfileException(PROFILE_NOT_FOUND));
   }
 }


### PR DESCRIPTION
### ✒️ 관련 이슈번호

- Close #143 

## 🔑 Key Changes

1. 프로필 상세 조회 컨트롤러 구현
2. 상세 조회 관련 정보를 담은 dto 구현
3. Set<ProfileGenre>를 Set<String>으로 변환하는 메서드 추가
4. 프로필과 프로필 장르를 fetch join 하는 쿼리 추가
5. 프로필 상세 조회 관련 서비스 구현
6. swagger mapping

## 📢 To Reviewers

- None