### PR TITLE
[Feat] : 공연 후기 수정 기능 구현

### DIFF
--- a/src/main/java/dnd/danverse/domain/member/entity/Member.java
+++ b/src/main/java/dnd/danverse/domain/member/entity/Member.java
@@ -3,6 +3,7 @@ package dnd.danverse.domain.member.entity;
 import dnd.danverse.domain.common.BaseTimeEntity;
 import dnd.danverse.domain.oauth.info.OAuth2Provider;
 import dnd.danverse.domain.profile.entity.Profile;
+import java.util.Objects;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -120,10 +121,13 @@ public class Member extends BaseTimeEntity {
   }
 
 
-
-
-
-
-
+  /**
+   * 사용자가 같은지 비교한다.
+   * @param stranger 비교할 사용자
+   * @return 같으면 true, 다르면 false
+   */
+  public boolean isNotSame(Long stranger) {
+    return !Objects.equals(this.id, stranger);
+  }
 }
 

--- a/src/main/java/dnd/danverse/domain/member/entity/Member.java
+++ b/src/main/java/dnd/danverse/domain/member/entity/Member.java
@@ -9,7 +9,6 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
-import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -47,7 +46,7 @@ public class Member extends BaseTimeEntity {
   /**
    * 사용자의 프로필 정보. OneToOne 관계이며, Member 의 프로필 정보를 조회할 때 사용한다.
    */
-  @OneToOne(mappedBy = "member", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
+  @OneToOne(mappedBy = "member", cascade = CascadeType.REMOVE)
   private Profile profile;
 
   /**

--- a/src/main/java/dnd/danverse/domain/review/controller/ReviewController.java
+++ b/src/main/java/dnd/danverse/domain/review/controller/ReviewController.java
@@ -95,20 +95,15 @@ public class ReviewController {
   /**
    * 후기를 수정한다.
    *
-   * @param performId 공연 고유 ID
    * @param updateDto 수정할 내용
    * @param user      API 요청자
    * @return 수정된 후기 정보
    */
-  @PatchMapping("/{performId}/reviews")
+  @PatchMapping("/reviews")
   @ApiOperation(value = "후기를 수정한다.", notes = "후기를 수정한다. 응답으로 수정된 후기 데이터 1건을 응답한다.")
-  @ApiImplicitParams({
-      @ApiImplicitParam(name = "performId", value = "공연 고유 ID", required = true, dataType = "long", paramType = "path"),
-      @ApiImplicitParam(name = "Authorization", value = "Bearer access_token (서버에서 발급한 access_token)",
-          required = true, dataType = "string", paramType = "header")
-  })
-  public ResponseEntity<DataResponse<ReviewInfoDto>> updateReview(
-      @PathVariable("performId") Long performId, @RequestBody ReviewUpdateDto updateDto,
+  @ApiImplicitParam(name = "Authorization", value = "Bearer access_token (서버에서 발급한 access_token)",
+      required = true, dataType = "string", paramType = "header")
+  public ResponseEntity<DataResponse<ReviewInfoDto>> updateReview(@RequestBody ReviewUpdateDto updateDto,
       @AuthenticationPrincipal SessionUser user) {
     ReviewInfoDto reviewInfoDto = reviewUpdateComplexService.updateReview(updateDto, user.getId());
     return new ResponseEntity<>(DataResponse.of(HttpStatus.OK, "리뷰가 성공적으로 수정되었습니다.", reviewInfoDto),

--- a/src/main/java/dnd/danverse/domain/review/controller/ReviewController.java
+++ b/src/main/java/dnd/danverse/domain/review/controller/ReviewController.java
@@ -2,9 +2,11 @@ package dnd.danverse.domain.review.controller;
 
 import dnd.danverse.domain.jwt.service.SessionUser;
 import dnd.danverse.domain.review.dto.request.ReviewContentDto;
+import dnd.danverse.domain.review.dto.request.ReviewUpdateDto;
 import dnd.danverse.domain.review.dto.response.ReviewInfoDto;
 import dnd.danverse.domain.review.dto.response.ReviewInfoWithPerformDto;
 import dnd.danverse.domain.review.service.ReviewSaveComplexService;
+import dnd.danverse.domain.review.service.ReviewUpdateComplexService;
 import dnd.danverse.domain.review.service.ReviewsSearchComplexService;
 import dnd.danverse.global.response.DataResponse;
 import io.swagger.annotations.Api;
@@ -17,6 +19,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -34,6 +37,7 @@ public class ReviewController {
 
   private final ReviewSaveComplexService reviewSaveComplexService;
   private final ReviewsSearchComplexService reviewsSearchComplexService;
+  private final ReviewUpdateComplexService reviewUpdateComplexService;
 
   /**
    * 후기를 저장한다.
@@ -52,7 +56,8 @@ public class ReviewController {
   public ResponseEntity<DataResponse<List<ReviewInfoDto>>> createReview(
       @PathVariable("performId") Long performId, @RequestBody ReviewContentDto contentDto,
       @AuthenticationPrincipal SessionUser user) {
-    List<ReviewInfoDto> allReviews = reviewSaveComplexService.saveReview(contentDto, performId, user.getId());
+    List<ReviewInfoDto> allReviews = reviewSaveComplexService.saveReview(contentDto, performId,
+        user.getId());
     return new ResponseEntity<>(
         DataResponse.of(HttpStatus.CREATED, "리뷰가 성공적으로 등록되었습니다.", allReviews),
         HttpStatus.CREATED);
@@ -60,13 +65,15 @@ public class ReviewController {
 
   /**
    * 공연에 대한 모든 후기를 조회한다.
+   *
    * @param performId 공연 고유 ID
    * @return 후기 정보
    */
   @GetMapping("/{performId}/reviews")
   @ApiOperation(value = "공연에 대한 모든 후기를 조회한다.", notes = "공연에 대한 모든 후기를 조회한다.")
   @ApiImplicitParam(name = "performId", value = "공연 고유 ID", required = true, dataType = "long", paramType = "path")
-  public ResponseEntity<DataResponse<List<ReviewInfoDto>>> findAllReviews(@PathVariable("performId") Long performId) {
+  public ResponseEntity<DataResponse<List<ReviewInfoDto>>> findAllReviews(
+      @PathVariable("performId") Long performId) {
     List<ReviewInfoDto> allReviews = reviewsSearchComplexService.findAllReviews(performId);
     return new ResponseEntity<>(DataResponse.of(HttpStatus.OK, "리뷰 조회에 성공했습니다.", allReviews),
         HttpStatus.OK);
@@ -74,6 +81,7 @@ public class ReviewController {
 
   /**
    * 최근 등록된 공연 후기를 6개 조회한다.
+   *
    * @return 후기 정보
    */
   @GetMapping("/recent/reviews")
@@ -81,6 +89,29 @@ public class ReviewController {
   public ResponseEntity<DataResponse<List<ReviewInfoWithPerformDto>>> findRecentReviews() {
     List<ReviewInfoWithPerformDto> recentReviews = reviewsSearchComplexService.findRecentReviews();
     return new ResponseEntity<>(DataResponse.of(HttpStatus.OK, "최근 리뷰 조회에 성공했습니다.", recentReviews),
+        HttpStatus.OK);
+  }
+
+  /**
+   * 후기를 수정한다.
+   *
+   * @param performId 공연 고유 ID
+   * @param updateDto 수정할 내용
+   * @param user      API 요청자
+   * @return 수정된 후기 정보
+   */
+  @PatchMapping("/{performId}/reviews")
+  @ApiOperation(value = "후기를 수정한다.", notes = "후기를 수정한다. 응답으로 수정된 후기 데이터 1건을 응답한다.")
+  @ApiImplicitParams({
+      @ApiImplicitParam(name = "performId", value = "공연 고유 ID", required = true, dataType = "long", paramType = "path"),
+      @ApiImplicitParam(name = "Authorization", value = "Bearer access_token (서버에서 발급한 access_token)",
+          required = true, dataType = "string", paramType = "header")
+  })
+  public ResponseEntity<DataResponse<ReviewInfoDto>> updateReview(
+      @PathVariable("performId") Long performId, @RequestBody ReviewUpdateDto updateDto,
+      @AuthenticationPrincipal SessionUser user) {
+    ReviewInfoDto reviewInfoDto = reviewUpdateComplexService.updateReview(updateDto, user.getId());
+    return new ResponseEntity<>(DataResponse.of(HttpStatus.OK, "리뷰가 성공적으로 수정되었습니다.", reviewInfoDto),
         HttpStatus.OK);
   }
 

--- a/src/main/java/dnd/danverse/domain/review/dto/request/ReviewUpdateDto.java
+++ b/src/main/java/dnd/danverse/domain/review/dto/request/ReviewUpdateDto.java
@@ -1,0 +1,26 @@
+package dnd.danverse.domain.review.dto.request;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 후기 수정을 위한 요청 Dto
+ */
+@Getter
+@NoArgsConstructor
+public class ReviewUpdateDto {
+
+  /**
+   * 후기 ID
+   */
+  @ApiModelProperty(value = "후기 고유 ID", example = "1")
+  private Long id;
+
+  /**
+   * 후기 내용
+   */
+  @ApiModelProperty(value = "수정하고자 하는 후기 내용")
+  private String review;
+
+}

--- a/src/main/java/dnd/danverse/domain/review/entity/Review.java
+++ b/src/main/java/dnd/danverse/domain/review/entity/Review.java
@@ -73,4 +73,14 @@ public class Review extends BaseTimeEntity {
     this.content = content;
   }
 
+  /**
+   * 리뷰 수정
+   * @param reviewContent 수정할 리뷰 내용
+   * @return 수정된 리뷰
+   */
+  public Review updateReview(String reviewContent) {
+    this.content = reviewContent;
+    return this;
+  }
+
 }

--- a/src/main/java/dnd/danverse/domain/review/exception/NotReviewWriterException.java
+++ b/src/main/java/dnd/danverse/domain/review/exception/NotReviewWriterException.java
@@ -1,0 +1,13 @@
+package dnd.danverse.domain.review.exception;
+
+import dnd.danverse.global.exception.BusinessException;
+import dnd.danverse.global.exception.ErrorCode;
+
+/**
+ * 리뷰 작성자가 아닌 사용자가 리뷰를 수정하거나 삭제하려고 할 때 발생하는 예외.
+ */
+public class NotReviewWriterException extends BusinessException {
+  public NotReviewWriterException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+}

--- a/src/main/java/dnd/danverse/domain/review/exception/ReviewNotFoundException.java
+++ b/src/main/java/dnd/danverse/domain/review/exception/ReviewNotFoundException.java
@@ -1,0 +1,14 @@
+package dnd.danverse.domain.review.exception;
+
+import dnd.danverse.global.exception.BusinessException;
+import dnd.danverse.global.exception.ErrorCode;
+
+/**
+ * 후기를 찾을 수 없을 때 발생하는 예외
+ */
+public class ReviewNotFoundException extends BusinessException {
+
+  public ReviewNotFoundException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+}

--- a/src/main/java/dnd/danverse/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/dnd/danverse/domain/review/repository/ReviewRepository.java
@@ -4,6 +4,7 @@ import dnd.danverse.domain.review.dto.response.ReviewInfoDto;
 import dnd.danverse.domain.review.dto.response.ReviewInfoWithPerformDto;
 import dnd.danverse.domain.review.entity.Review;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -23,4 +24,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
       + "ReviewInfoWithPerformDto(r.id,r.content, r.createdAt, m.id,m.name, p.id,p.profileName, pe.id, pe.title, pe.performanceImg.imageUrl)"
       + " from Review r join r.member m left join m.profile p join r.performance pe order by r.createdAt desc")
   List<ReviewInfoWithPerformDto> findRecentReviews();
+
+  @Query("select r from Review r join fetch r.member m left join fetch m.profile p where r.id = :reviewId")
+  Optional<Review> findReviewWithMemberById(@Param("reviewId") Long reviewId);
 }

--- a/src/main/java/dnd/danverse/domain/review/service/ReviewPureService.java
+++ b/src/main/java/dnd/danverse/domain/review/service/ReviewPureService.java
@@ -1,8 +1,11 @@
 package dnd.danverse.domain.review.service;
 
+import static dnd.danverse.global.exception.ErrorCode.REVIEW_NOT_FOUND;
+
 import dnd.danverse.domain.review.dto.response.ReviewInfoDto;
 import dnd.danverse.domain.review.dto.response.ReviewInfoWithPerformDto;
 import dnd.danverse.domain.review.entity.Review;
+import dnd.danverse.domain.review.exception.ReviewNotFoundException;
 import dnd.danverse.domain.review.repository.ReviewRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -65,7 +68,7 @@ public class ReviewPureService {
   @Transactional(readOnly = true)
   public Review findReviewWithMemberById(Long reviewId) {
     log.info("Review 와 Member 와 Profile 을 fetch join 조회한다. 리뷰 ID : {} ", reviewId);
-    return reviewRepository.findReviewWithMemberById(reviewId).orElseThrow(() -> new IllegalArgumentException("해당 리뷰가 없습니다. reviewId = " + reviewId));
+    return reviewRepository.findReviewWithMemberById(reviewId).orElseThrow(() -> new ReviewNotFoundException(REVIEW_NOT_FOUND));
   }
 
   /**

--- a/src/main/java/dnd/danverse/domain/review/service/ReviewPureService.java
+++ b/src/main/java/dnd/danverse/domain/review/service/ReviewPureService.java
@@ -55,4 +55,28 @@ public class ReviewPureService {
   public List<ReviewInfoWithPerformDto> findRecentReviews() {
     return reviewRepository.findRecentReviews();
   }
+
+  /**
+   * 공연에 대한 리뷰를 조회한다
+   * Review, Member, Profile 을 fetch join 한다.
+   * @param reviewId 리뷰 ID
+   * @return 리뷰
+   */
+  @Transactional(readOnly = true)
+  public Review findReviewWithMemberById(Long reviewId) {
+    log.info("Review 와 Member 와 Profile 을 fetch join 조회한다. 리뷰 ID : {} ", reviewId);
+    return reviewRepository.findReviewWithMemberById(reviewId).orElseThrow(() -> new IllegalArgumentException("해당 리뷰가 없습니다. reviewId = " + reviewId));
+  }
+
+  /**
+   * Review 를 수정 한다.
+   * @param review 수정하고자 하는 Review
+   * @param reviewContent 수정하고자 하는 Review 내용
+   * @return 수정된 Review
+   */
+  @Transactional
+  public Review updateReview(Review review, String reviewContent) {
+    log.info("Review 를 수정한다. 내용 : {} ", reviewContent);
+    return review.updateReview(reviewContent);
+  }
 }

--- a/src/main/java/dnd/danverse/domain/review/service/ReviewUpdateComplexService.java
+++ b/src/main/java/dnd/danverse/domain/review/service/ReviewUpdateComplexService.java
@@ -1,0 +1,37 @@
+package dnd.danverse.domain.review.service;
+
+import dnd.danverse.domain.review.dto.request.ReviewUpdateDto;
+import dnd.danverse.domain.review.dto.response.ReviewInfoDto;
+import dnd.danverse.domain.review.entity.Review;
+import dnd.danverse.domain.validation.ReviewWriterValidationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * 후기 수정을 위한 복합 Service
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ReviewUpdateComplexService {
+
+  private final ReviewPureService reviewPureService;
+  private final ReviewWriterValidationService reviewWriterValidationService;
+
+
+  /**
+   * 후기를 수정한다.
+   *
+   * @param updateDto 수정할 후기 정보
+   * @param memberId 수정자 ID
+   * @return 수정된 후기 정보
+   */
+  public ReviewInfoDto updateReview(ReviewUpdateDto updateDto, Long memberId) {
+    Review review = reviewWriterValidationService.validateReviewWriter(updateDto.getId(), memberId);
+
+    reviewPureService.updateReview(review, updateDto.getReview());
+
+    return new ReviewInfoDto(review, review.getMember());
+  }
+}

--- a/src/main/java/dnd/danverse/domain/validation/ReviewWriterValidationService.java
+++ b/src/main/java/dnd/danverse/domain/validation/ReviewWriterValidationService.java
@@ -1,0 +1,41 @@
+package dnd.danverse.domain.validation;
+
+import static dnd.danverse.global.exception.ErrorCode.REVIEW_NOT_WRITER;
+
+import dnd.danverse.domain.member.entity.Member;
+import dnd.danverse.domain.review.entity.Review;
+import dnd.danverse.domain.review.exception.NotReviewWriterException;
+import dnd.danverse.domain.review.service.ReviewPureService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 후기 작성자 검증 복합 half Service
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ReviewWriterValidationService {
+
+  private final ReviewPureService reviewPureService;
+
+  /**
+   * 후기 작성자 검증
+   * @param reviewId 후기 ID
+   * @param memberId API 요청자 ID
+   * @return 후기
+   */
+  @Transactional(readOnly = true)
+  public Review validateReviewWriter(Long reviewId, Long memberId) {
+    Review review = reviewPureService.findReviewWithMemberById(reviewId);
+    Member writer = review.getMember();
+
+    if (writer.isNotSame(memberId)) {
+      throw new NotReviewWriterException(REVIEW_NOT_WRITER);
+    }
+
+    return review;
+  }
+}

--- a/src/main/java/dnd/danverse/global/exception/ErrorCode.java
+++ b/src/main/java/dnd/danverse/global/exception/ErrorCode.java
@@ -41,6 +41,9 @@ public enum ErrorCode {
   // 프로필
   PROFILE_NOT_FOUND(HttpStatus.BAD_REQUEST, "P001", "프로필 등록이 필요한 서비스입니다."),
 
+  // 후기
+  REVIEW_NOT_WRITER(HttpStatus.FORBIDDEN, "R001", "작성자 외에 접근 권한이 없습니다."),
+
   // Enum Type
   TYPE_NOT_FOUND(HttpStatus.BAD_REQUEST, "T001", "해당 타입은 존재하지 않습니다."),
 

--- a/src/main/java/dnd/danverse/global/exception/ErrorCode.java
+++ b/src/main/java/dnd/danverse/global/exception/ErrorCode.java
@@ -43,6 +43,7 @@ public enum ErrorCode {
 
   // 후기
   REVIEW_NOT_WRITER(HttpStatus.FORBIDDEN, "R001", "작성자 외에 접근 권한이 없습니다."),
+  REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "R002", "존재하지 않는 후기입니다."),
 
   // Enum Type
   TYPE_NOT_FOUND(HttpStatus.BAD_REQUEST, "T001", "해당 타입은 존재하지 않습니다."),

--- a/src/main/java/dnd/danverse/global/security/config/SecurityConfig.java
+++ b/src/main/java/dnd/danverse/global/security/config/SecurityConfig.java
@@ -51,7 +51,8 @@ public class SecurityConfig {
         .antMatchers(HttpMethod.DELETE, "/api/v1/events/{eventId}/cancel-apply", "/api/v1/events/{eventId}", "/api/v1/performances/{performId}")
           .hasAuthority(userRole)
         .antMatchers(HttpMethod.GET, "/api/v1/events/{eventId}/applicants").hasAuthority(userRole)
-        .antMatchers(HttpMethod.PATCH, "/api/v1/events/{eventId}/accept", "/api/v1/events/deadline", "/api/v1/performances")
+        .antMatchers(HttpMethod.PATCH, "/api/v1/events/{eventId}/accept", "/api/v1/events/deadline", "/api/v1/performances",
+            "/api/v1/performances/reviews")
           .hasAuthority(userRole)
         .anyRequest().permitAll();
 


### PR DESCRIPTION
### ✒️ 관련 이슈번호

- Close #153 

## 🔑 Key Changes

1. 공연 후기 수정 기능 구현
2. 후기 작성자가 아닌 사람이 수정 시도 시, exception 발생
3. member 와 profile 은 일대일 관계이며 member 입장에서는 profile에 대한 외래키가 없기 때문에 profile에 대한 프록시 객체를 만들 수 없어 lazy loading 이 아닌 eager로 동작하게 된다. 그러므로 fetchType=LAZY를 삭제

## 📢 To Reviewers

- 후기 작성자가 맞는지 검증하는 ValidationService는 추후 객체 지향적으로 리팩토링 하는 시간을 갖도록 하겠습니다.