### PR TITLE
[Feat] : 프로필 등록 기능 구현

### DIFF
--- a/src/main/java/dnd/danverse/domain/profile/controller/ProfileController.java
+++ b/src/main/java/dnd/danverse/domain/profile/controller/ProfileController.java
@@ -1,19 +1,26 @@
 package dnd.danverse.domain.profile.controller;
 
+import dnd.danverse.domain.jwt.service.SessionUser;
+import dnd.danverse.domain.profile.dto.request.ProfileSaveRequestDto;
 import dnd.danverse.domain.profile.dto.response.ProfileHomeDto;
 import dnd.danverse.domain.profile.dto.response.ProfileWithGenreDto;
 import dnd.danverse.domain.profile.service.ProfileDetailService;
+import dnd.danverse.domain.profile.service.ProfileSaveService;
 import dnd.danverse.domain.profile.service.ProfileSearchService;
 import dnd.danverse.global.response.DataResponse;
 import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiOperation;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 
@@ -28,6 +35,7 @@ public class ProfileController {
 
   private final ProfileSearchService profileSearchService;
   private final ProfileDetailService profileDetailService;
+  private final ProfileSaveService profileSaveService;
 
   /**
    * 서비스 사용자는 실제 사용자의 프로필 6개를 랜덤으로 조회할 수 있습니다.
@@ -49,6 +57,19 @@ public class ProfileController {
   public ResponseEntity<DataResponse<ProfileWithGenreDto>> getProfile(@PathVariable("profileId") Long profileId) {
     ProfileWithGenreDto profileWithGenreDto = profileDetailService.getProfile(profileId);
     return new ResponseEntity<>(DataResponse.of(HttpStatus.OK, "프로필 상세 조회 성공", profileWithGenreDto), HttpStatus.OK);
+  }
+
+  /**
+   * 로그인한 사용자는 프로필을 등록할 수 있습니다.
+   */
+  @PostMapping()
+  @ApiOperation(value = "프로필 등록", notes = "로그인한 사용자에 한하여 프로필 등록")
+  @ApiImplicitParam(name = "Authorization", value = "Bearer access_token (서버에서 발급한 access_token)",
+      required = true, dataType = "string", paramType = "header")
+  public ResponseEntity<DataResponse<ProfileWithGenreDto>> saveProfile(@RequestBody ProfileSaveRequestDto request,
+      @AuthenticationPrincipal SessionUser sessionUser) {
+    ProfileWithGenreDto profileResponse = profileSaveService.saveProfile(request, sessionUser.getId());
+    return new ResponseEntity<>(DataResponse.of(HttpStatus.CREATED, "프로필 등록 성공", profileResponse), HttpStatus.CREATED);
   }
 
 

--- a/src/main/java/dnd/danverse/domain/profile/controller/ProfileController.java
+++ b/src/main/java/dnd/danverse/domain/profile/controller/ProfileController.java
@@ -2,6 +2,7 @@ package dnd.danverse.domain.profile.controller;
 
 import dnd.danverse.domain.jwt.service.SessionUser;
 import dnd.danverse.domain.profile.dto.request.ProfileSaveRequestDto;
+import dnd.danverse.domain.profile.dto.response.ProfileDetailResponseDto;
 import dnd.danverse.domain.profile.dto.response.ProfileHomeDto;
 import dnd.danverse.domain.profile.dto.response.ProfileWithGenreDto;
 import dnd.danverse.domain.profile.service.ProfileDetailService;
@@ -66,9 +67,9 @@ public class ProfileController {
   @ApiOperation(value = "프로필 등록", notes = "로그인한 사용자에 한하여 프로필 등록")
   @ApiImplicitParam(name = "Authorization", value = "Bearer access_token (서버에서 발급한 access_token)",
       required = true, dataType = "string", paramType = "header")
-  public ResponseEntity<DataResponse<ProfileWithGenreDto>> saveProfile(@RequestBody ProfileSaveRequestDto request,
+  public ResponseEntity<DataResponse<ProfileDetailResponseDto>> saveProfile(@RequestBody ProfileSaveRequestDto request,
       @AuthenticationPrincipal SessionUser sessionUser) {
-    ProfileWithGenreDto profileResponse = profileSaveService.saveProfile(request, sessionUser.getId());
+    ProfileDetailResponseDto profileResponse = profileSaveService.saveProfile(request, sessionUser.getId());
     return new ResponseEntity<>(DataResponse.of(HttpStatus.CREATED, "프로필 등록 성공", profileResponse), HttpStatus.CREATED);
   }
 

--- a/src/main/java/dnd/danverse/domain/profile/dto/request/ProfileSaveRequestDto.java
+++ b/src/main/java/dnd/danverse/domain/profile/dto/request/ProfileSaveRequestDto.java
@@ -43,14 +43,37 @@ public class ProfileSaveRequestDto {
   @ApiModelProperty(value = "프로필 오픈챗 url")
   private String openChatUrl;
 
-  @ApiModelProperty(value = "포트폴리오 인스타 url")
-  private String instagramUrl;
+  /**
+   * 프로필의 작성자의 포트폴리오 URL Dto.
+   */
+  @ApiModelProperty(value = "프로필의 포트폴리오 정보")
+  private PortfolioUrl portfolioUrl;
 
-  @ApiModelProperty(value = "포트폴리오 유튜브 url")
-  private String youtubeUrl;
+  /**
+   * 프로필의 작성자의 포트폴리오 URL Dto.
+   */
+  @Getter
+  public static class PortfolioUrl {
 
-  @ApiModelProperty(value = "포트폴리오 트위터 url")
-  private String twitterUrl;
+    /**
+     * 프로필의 작성자의 유튜브 URL.
+     */
+    @ApiModelProperty(value = "포트폴리오의 유튜브 URL")
+    private String youtube;
+
+    /**
+     * 프로필의 작성자의 인스타그램 URL.
+     */
+    @ApiModelProperty(value = "포트폴리오의 인스타 URL")
+    private String instagram;
+
+    /**
+     * 프로필의 작성자의 트위터 URL.
+     */
+    @ApiModelProperty(value = "포트폴리오의 트위터 URL")
+    private String twitter;
+
+  }
 
   public Profile toEntity(Member member) {
     Profile profile = Profile.builder()
@@ -62,7 +85,7 @@ public class ProfileSaveRequestDto {
         .careerStartDay(this.careerStartDate)
         .description(this.description)
         .openChatUrl(new OpenChat(this.openChatUrl))
-        .portfolioUrl(new Portfolio(this.instagramUrl, this.youtubeUrl, this.twitterUrl))
+        .portfolioUrl(new Portfolio(this.portfolioUrl))
         .build();
 
     this.genres.stream()

--- a/src/main/java/dnd/danverse/domain/profile/dto/request/ProfileSaveRequestDto.java
+++ b/src/main/java/dnd/danverse/domain/profile/dto/request/ProfileSaveRequestDto.java
@@ -1,0 +1,75 @@
+package dnd.danverse.domain.profile.dto.request;
+
+import dnd.danverse.domain.common.Image;
+import dnd.danverse.domain.common.TeamType;
+import dnd.danverse.domain.member.entity.Member;
+import dnd.danverse.domain.profile.entity.OpenChat;
+import dnd.danverse.domain.profile.entity.Portfolio;
+import dnd.danverse.domain.profile.entity.Profile;
+import dnd.danverse.domain.profilegenre.entity.ProfileGenre;
+import io.swagger.annotations.ApiModelProperty;
+import java.time.LocalDate;
+import java.util.Set;
+import javax.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ProfileSaveRequestDto {
+
+  @ApiModelProperty(value = "프로필 타입 ex) 댄서, 댄스팀")
+  private String type;
+
+  @ApiModelProperty(value = "프로필 이미지 url")
+  private String imgUrl;
+
+  @ApiModelProperty(value = "프로필 이름")
+  private String name;
+
+  @ApiModelProperty(value = "프로필 관심 장르")
+  @Size(max = 3, min = 1, message = "장르는 최대 3개, 최소 1개까지 선택 가능합니다.")
+  private Set<String> genres;
+
+  @ApiModelProperty(value = "프로필 활동지역")
+  private String location;
+
+  @ApiModelProperty(value = "댄스 경력")
+  private LocalDate careerStartDate;
+
+  @ApiModelProperty(value = "프로필 상세 소개")
+  private String description;
+
+  @ApiModelProperty(value = "프로필 오픈챗 url")
+  private String openChatUrl;
+
+  @ApiModelProperty(value = "포트폴리오 인스타 url")
+  private String instagramUrl;
+
+  @ApiModelProperty(value = "포트폴리오 유튜브 url")
+  private String youtubeUrl;
+
+  @ApiModelProperty(value = "포트폴리오 트위터 url")
+  private String twitterUrl;
+
+  public Profile toEntity(Member member) {
+    Profile profile = Profile.builder()
+        .member(member)
+        .profileType(TeamType.of(this.type))
+        .profileImg(new Image(this.imgUrl))
+        .profileName(this.name)
+        .location(this.location)
+        .careerStartDay(this.careerStartDate)
+        .description(this.description)
+        .openChatUrl(new OpenChat(this.openChatUrl))
+        .portfolioUrl(new Portfolio(this.instagramUrl, this.youtubeUrl, this.twitterUrl))
+        .build();
+
+    this.genres.stream()
+        .map(ProfileGenre::new)
+        .forEach(profileGenre -> profileGenre.addProfile(profile));
+
+    return profile;
+  }
+
+}

--- a/src/main/java/dnd/danverse/domain/profile/dto/request/ProfileSaveRequestDto.java
+++ b/src/main/java/dnd/danverse/domain/profile/dto/request/ProfileSaveRequestDto.java
@@ -3,6 +3,7 @@ package dnd.danverse.domain.profile.dto.request;
 import dnd.danverse.domain.common.Image;
 import dnd.danverse.domain.common.TeamType;
 import dnd.danverse.domain.member.entity.Member;
+import dnd.danverse.domain.profile.dto.response.PortfolioUrl;
 import dnd.danverse.domain.profile.entity.OpenChat;
 import dnd.danverse.domain.profile.entity.Portfolio;
 import dnd.danverse.domain.profile.entity.Profile;
@@ -14,6 +15,9 @@ import javax.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+/**
+ * 프로필 등록을 위한 요청 Dto.
+ */
 @Getter
 @NoArgsConstructor
 public class ProfileSaveRequestDto {
@@ -49,32 +53,6 @@ public class ProfileSaveRequestDto {
   @ApiModelProperty(value = "프로필의 포트폴리오 정보")
   private PortfolioUrl portfolioUrl;
 
-  /**
-   * 프로필의 작성자의 포트폴리오 URL Dto.
-   */
-  @Getter
-  public static class PortfolioUrl {
-
-    /**
-     * 프로필의 작성자의 유튜브 URL.
-     */
-    @ApiModelProperty(value = "포트폴리오의 유튜브 URL")
-    private String youtube;
-
-    /**
-     * 프로필의 작성자의 인스타그램 URL.
-     */
-    @ApiModelProperty(value = "포트폴리오의 인스타 URL")
-    private String instagram;
-
-    /**
-     * 프로필의 작성자의 트위터 URL.
-     */
-    @ApiModelProperty(value = "포트폴리오의 트위터 URL")
-    private String twitter;
-
-  }
-
   public Profile toEntity(Member member) {
     Profile profile = Profile.builder()
         .member(member)
@@ -85,7 +63,8 @@ public class ProfileSaveRequestDto {
         .careerStartDay(this.careerStartDate)
         .description(this.description)
         .openChatUrl(new OpenChat(this.openChatUrl))
-        .portfolioUrl(new Portfolio(this.portfolioUrl))
+        .portfolioUrl(new Portfolio(this.portfolioUrl.getYoutube(),
+            this.portfolioUrl.getInstagram(), this.portfolioUrl.getTwitter()))
         .build();
 
     this.genres.stream()

--- a/src/main/java/dnd/danverse/domain/profile/dto/response/PortfolioUrl.java
+++ b/src/main/java/dnd/danverse/domain/profile/dto/response/PortfolioUrl.java
@@ -1,0 +1,43 @@
+package dnd.danverse.domain.profile.dto.response;
+
+import dnd.danverse.domain.profile.entity.Portfolio;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 포트폴리오 url 들을 담은 Dto.
+ */
+@Getter
+@NoArgsConstructor
+public class PortfolioUrl {
+
+  /**
+   * 프로필의 작성자의 유튜브 URL.
+   */
+  @ApiModelProperty(value = "포트폴리오의 유튜브 URL")
+  private String youtube;
+
+  /**
+   * 프로필의 작성자의 인스타그램 URL.
+   */
+  @ApiModelProperty(value = "포트폴리오의 인스타 URL")
+  private String instagram;
+
+  /**
+   * 프로필의 작성자의 트위터 URL.
+   */
+  @ApiModelProperty(value = "포트폴리오의 트위터 URL")
+  private String twitter;
+
+  /**
+   * 포트폴리오의 실제 url 데이터를 dto 데이터로 매핑한다.
+   *
+   * @param portfolio dto 로 변환하는 포트폴리오 객체.
+   */
+  public PortfolioUrl(Portfolio portfolio) {
+    this.youtube = portfolio.getYoutubeUrl();
+    this.instagram = portfolio.getInstagramUrl();
+    this.twitter = portfolio.getTwitterUrl();
+  }
+}

--- a/src/main/java/dnd/danverse/domain/profile/dto/response/ProfileDetailResponseDto.java
+++ b/src/main/java/dnd/danverse/domain/profile/dto/response/ProfileDetailResponseDto.java
@@ -1,0 +1,59 @@
+package dnd.danverse.domain.profile.dto.response;
+
+import dnd.danverse.domain.profile.entity.Profile;
+import io.swagger.annotations.ApiModelProperty;
+import java.time.LocalDate;
+import java.util.Set;
+import lombok.Getter;
+
+/**
+ * 프로필 정보를 반환하는 응답 Dto.
+ */
+@Getter
+public class ProfileDetailResponseDto {
+
+  @ApiModelProperty(name = "프로필의 고유 Id")
+  private final Long id;
+
+  @ApiModelProperty(name = "프로필 이름")
+  private final String profileName;
+
+  @ApiModelProperty(name = "프로필 이미지 url")
+  private final String imgUrl;
+
+  @ApiModelProperty(name = "프로필 활동 지역")
+  private final String location;
+
+  @ApiModelProperty(name = "프로필 관심 장르")
+  private final Set<String> genres;
+
+  @ApiModelProperty(name = "커리어 시작 날짜")
+  private final LocalDate startDate;
+
+  @ApiModelProperty(name = "프로필 상세 설명")
+  private final String description;
+
+  @ApiModelProperty(name = "프로필 오픈채팅 url")
+  private final String openChatUrl;
+
+  @ApiModelProperty(name = "프로필의 포트폴리오 url")
+  private final PortfolioUrl portfolio;
+
+  /**
+   * 입력받은 프로필을 통해서 프로필 정보를 반환하는 dto 생성자.
+   *
+   * @param profile 정보 반환을 원하는 프로필 객체.
+   */
+  public ProfileDetailResponseDto(Profile profile) {
+    this.id = profile.getId();
+    this.profileName = profile.getProfileName();
+    this.imgUrl = profile.getProfileImg().getImageUrl();
+    this.location = profile.getLocation();
+    this.genres = profile.toStringProfileGenre();
+    this.startDate = profile.getCareerStartDay();
+    this.description = profile.getDescription();
+    this.openChatUrl = profile.getOpenChatUrl().getOpenChatUrl();
+    this.portfolio = new PortfolioUrl(profile.getPortfolioUrl());
+  }
+
+}

--- a/src/main/java/dnd/danverse/domain/profile/dto/response/ProfileInfoDto.java
+++ b/src/main/java/dnd/danverse/domain/profile/dto/response/ProfileInfoDto.java
@@ -1,6 +1,5 @@
 package dnd.danverse.domain.profile.dto.response;
 
-import dnd.danverse.domain.profile.entity.Portfolio;
 import dnd.danverse.domain.profile.entity.Profile;
 import io.swagger.annotations.ApiModelProperty;
 import java.time.LocalDate;
@@ -66,36 +65,6 @@ public class ProfileInfoDto {
   @ApiModelProperty(value = "프로필의 포트폴리오 정보")
   private final PortfolioUrl portfolioUrl;
 
-  /**
-   * 프로필의 작성자의 포트폴리오 URL Dto.
-   */
-  @Getter
-  public static class PortfolioUrl {
-
-    /**
-     * 프로필의 작성자의 유튜브 URL.
-     */
-    @ApiModelProperty(value = "포트폴리오의 유튜브 URL")
-    private final String youtube;
-
-    /**
-     * 프로필의 작성자의 인스타그램 URL.
-     */
-    @ApiModelProperty(value = "포트폴리오의 인스타 URL")
-    private final String instagram;
-
-    /**
-     * 프로필의 작성자의 트위터 URL.
-     */
-    @ApiModelProperty(value = "포트폴리오의 트위터 URL")
-    private final String twitter;
-
-    public PortfolioUrl(Portfolio portfolio) {
-      this.youtube = portfolio.getYoutubeUrl();
-      this.instagram = portfolio.getInstagramUrl();
-      this.twitter = portfolio.getTwitterUrl();
-    }
-  }
 
   /**
    * Profile 객체를 이용하여 ProfileInfoDto 를 생성한다.

--- a/src/main/java/dnd/danverse/domain/profile/entity/Portfolio.java
+++ b/src/main/java/dnd/danverse/domain/profile/entity/Portfolio.java
@@ -1,7 +1,5 @@
 package dnd.danverse.domain.profile.entity;
 
-
-import dnd.danverse.domain.profile.dto.request.ProfileSaveRequestDto.PortfolioUrl;
 import javax.persistence.Embeddable;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,21 +16,10 @@ public class Portfolio {
   private String youtubeUrl;
   private String instagramUrl;
   private String twitterUrl;
-
+  
   public Portfolio(String youtubeUrl, String instagramUrl, String twitterUrl) {
     this.youtubeUrl = youtubeUrl;
     this.instagramUrl = instagramUrl;
     this.twitterUrl = twitterUrl;
-  }
-
-  /**
-   * 포트폴리오 정보를 담는 dto를 엔티티로 변환한다.
-   *
-   * @param portfolio 포트폴리오 정보를 담은 Dto.
-   */
-  public Portfolio(PortfolioUrl portfolio) {
-    this.youtubeUrl = portfolio.getYoutube();
-    this.instagramUrl = portfolio.getInstagram();
-    this.twitterUrl = portfolio.getTwitter();
   }
 }

--- a/src/main/java/dnd/danverse/domain/profile/entity/Portfolio.java
+++ b/src/main/java/dnd/danverse/domain/profile/entity/Portfolio.java
@@ -1,6 +1,7 @@
 package dnd.danverse.domain.profile.entity;
 
 
+import dnd.danverse.domain.profile.dto.request.ProfileSaveRequestDto.PortfolioUrl;
 import javax.persistence.Embeddable;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -24,4 +25,14 @@ public class Portfolio {
     this.twitterUrl = twitterUrl;
   }
 
+  /**
+   * 포트폴리오 정보를 담는 dto를 엔티티로 변환한다.
+   *
+   * @param portfolio 포트폴리오 정보를 담은 Dto.
+   */
+  public Portfolio(PortfolioUrl portfolio) {
+    this.youtubeUrl = portfolio.getYoutube();
+    this.instagramUrl = portfolio.getInstagram();
+    this.twitterUrl = portfolio.getTwitter();
+  }
 }

--- a/src/main/java/dnd/danverse/domain/profile/entity/Profile.java
+++ b/src/main/java/dnd/danverse/domain/profile/entity/Profile.java
@@ -129,11 +129,10 @@ public class Profile extends BaseTimeEntity {
 
 
   @Builder
-  public Profile(Member member, Set<ProfileGenre> profileGenres, TeamType profileType, String profileName,
+  public Profile(Member member, TeamType profileType, String profileName,
       Image profileImg, String location, LocalDate careerStartDay, String description,
       OpenChat openChatUrl, Portfolio portfolioUrl) {
     this.member = member;
-    this.profileGenres = profileGenres;
     this.profileType = profileType;
     this.profileName = profileName;
     this.profileImg = profileImg;

--- a/src/main/java/dnd/danverse/domain/profile/exception/ProfileAlreadyException.java
+++ b/src/main/java/dnd/danverse/domain/profile/exception/ProfileAlreadyException.java
@@ -1,0 +1,13 @@
+package dnd.danverse.domain.profile.exception;
+
+import dnd.danverse.global.exception.BusinessException;
+import dnd.danverse.global.exception.ErrorCode;
+
+/**
+ * 프로필을 등록할 때 프로필이 이미 존재하면 예외가 발생한다.
+ */
+public class ProfileAlreadyException extends BusinessException {
+  public ProfileAlreadyException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+}

--- a/src/main/java/dnd/danverse/domain/profile/service/ProfilePureService.java
+++ b/src/main/java/dnd/danverse/domain/profile/service/ProfilePureService.java
@@ -67,7 +67,7 @@ public class ProfilePureService {
    */
   @Transactional
   public Profile saveProfile(Profile profile) {
-    log.info("memberId: {}의 프로필을 저장합니다.", profile.getMember().getId());
+    log.info("저장되는 프로필 이름 {}", profile.getProfileName());
     return profileRepository.save(profile);
   }
 

--- a/src/main/java/dnd/danverse/domain/profile/service/ProfilePureService.java
+++ b/src/main/java/dnd/danverse/domain/profile/service/ProfilePureService.java
@@ -1,9 +1,11 @@
 package dnd.danverse.domain.profile.service;
 
+import static dnd.danverse.global.exception.ErrorCode.PROFILE_ALREADY_EXISTS;
 import static dnd.danverse.global.exception.ErrorCode.PROFILE_NOT_FOUND;
 
 import dnd.danverse.domain.profile.entity.Profile;
 import dnd.danverse.domain.profile.exception.NoProfileException;
+import dnd.danverse.domain.profile.exception.ProfileAlreadyException;
 import dnd.danverse.domain.profile.repository.ProfileRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -22,8 +24,7 @@ public class ProfilePureService {
   private final ProfileRepository profileRepository;
 
   /**
-   * 프로필 조회
-   * 프로필이 존재하지 않으면 예외를 발생시킨다.
+   * 프로필 조회 프로필이 존재하지 않으면 예외를 발생시킨다.
    *
    * @param memberId 사용자 (member 고유 DB ID)
    * @return 프로필
@@ -46,9 +47,8 @@ public class ProfilePureService {
   }
 
   /**
-   * 프로필을 상세 조회합니다.
-   * 프로필과 프로필 장르를 fetch join 하여 profile 을 반환합니다.
-   * 요청한 profile Id 에 해당하는 프로필이 없다면 예외로 처리합니다.
+   * 프로필을 상세 조회합니다. 프로필과 프로필 장르를 fetch join 하여 profile 을 반환합니다. 요청한 profile Id 에 해당하는 프로필이 없다면 예외로
+   * 처리합니다.
    *
    * @param profileId 조회하려고 하는 profile 고유 Id.
    * @return Profile.
@@ -58,5 +58,30 @@ public class ProfilePureService {
     log.info("profileId: {}를 통해서 profile 과 profileGenre 를 fetch join 하여 찾습니다.", profileId);
     return profileRepository.findProfileWithGenreById(profileId)
         .orElseThrow(() -> new NoProfileException(PROFILE_NOT_FOUND));
+  }
+
+  /**
+   * 프로필을 저장합니다.
+   *
+   * @param profile 저장하려고 하는 프로필.
+   */
+  @Transactional
+  public Profile saveProfile(Profile profile) {
+    log.info("memberId: {}의 프로필을 저장합니다.", profile.getMember().getId());
+    return profileRepository.save(profile);
+  }
+
+  /**
+   * 프로필 등록 요청을 하는 사용자가 프로필을 가지고 있는지 확인합니다.
+   * 이미 존재한다면 예외처리를 합니다.
+   *
+   * @param memberId 프로필 등록 요청하는 사용자 Id.
+   */
+  @Transactional(readOnly = true)
+  public void checkIfHasProfile(Long memberId) {
+    log.info("memberId: {}의 멤버가 프로필을 가지고 있는지 확인합니다.", memberId);
+    profileRepository.findByMember(memberId).ifPresent(profile -> {
+      throw new ProfileAlreadyException(PROFILE_ALREADY_EXISTS);
+    });
   }
 }

--- a/src/main/java/dnd/danverse/domain/profile/service/ProfileSaveService.java
+++ b/src/main/java/dnd/danverse/domain/profile/service/ProfileSaveService.java
@@ -1,0 +1,36 @@
+package dnd.danverse.domain.profile.service;
+
+import dnd.danverse.domain.member.entity.Member;
+import dnd.danverse.domain.member.service.MemberPureService;
+import dnd.danverse.domain.profile.dto.request.ProfileSaveRequestDto;
+import dnd.danverse.domain.profile.dto.response.ProfileWithGenreDto;
+import dnd.danverse.domain.profile.entity.Profile;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * 프로필 등록 복합 서비스.
+ */
+@Service
+@RequiredArgsConstructor
+public class ProfileSaveService {
+
+  private final ProfilePureService profilePureService;
+  private final MemberPureService memberPureService;
+
+  /**
+   * 로그인이 되어있고, 프로필이 없는 사용자에 한해서 프로필 등록이 가능합니다.
+   * 프로필이 있는 사용자가 등록 요청을 할 경우, ProfileAlreadyException 처리가 됩니다.
+   *
+   * @param request 프로필 요청 Dto.
+   * @param memberId 프로필 등록 요청하는 멤버 Id.
+   * @return 프로필 응답 Dto.
+   */
+  public ProfileWithGenreDto saveProfile(ProfileSaveRequestDto request, Long memberId) {
+    Member member = memberPureService.findMemberWithProfile(memberId);
+    profilePureService.checkIfHasProfile(memberId);
+    Profile profile = profilePureService.saveProfile(request.toEntity(member));
+    return new ProfileWithGenreDto(profile);
+  }
+
+}

--- a/src/main/java/dnd/danverse/domain/profile/service/ProfileSaveService.java
+++ b/src/main/java/dnd/danverse/domain/profile/service/ProfileSaveService.java
@@ -3,7 +3,7 @@ package dnd.danverse.domain.profile.service;
 import dnd.danverse.domain.member.entity.Member;
 import dnd.danverse.domain.member.service.MemberPureService;
 import dnd.danverse.domain.profile.dto.request.ProfileSaveRequestDto;
-import dnd.danverse.domain.profile.dto.response.ProfileWithGenreDto;
+import dnd.danverse.domain.profile.dto.response.ProfileDetailResponseDto;
 import dnd.danverse.domain.profile.entity.Profile;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -26,11 +26,11 @@ public class ProfileSaveService {
    * @param memberId 프로필 등록 요청하는 멤버 Id.
    * @return 프로필 응답 Dto.
    */
-  public ProfileWithGenreDto saveProfile(ProfileSaveRequestDto request, Long memberId) {
+  public ProfileDetailResponseDto saveProfile(ProfileSaveRequestDto request, Long memberId) {
     Member member = memberPureService.findMemberWithProfile(memberId);
     profilePureService.checkIfHasProfile(memberId);
     Profile profile = profilePureService.saveProfile(request.toEntity(member));
-    return new ProfileWithGenreDto(profile);
+    return new ProfileDetailResponseDto(profile);
   }
 
 }

--- a/src/main/java/dnd/danverse/domain/profilegenre/entity/ProfileGenre.java
+++ b/src/main/java/dnd/danverse/domain/profilegenre/entity/ProfileGenre.java
@@ -52,5 +52,14 @@ public class ProfileGenre extends BaseTimeEntity {
     this.genre = genre;
   }
 
+  /**
+   * 양방향 관계 편의 메서드.
+   *
+   * @param profile 장르를 저장하려는 프로필.
+   */
+  public void addProfile(Profile profile) {
+    this.profile = profile;
+    profile.getProfileGenres().add(this);
+  }
 
 }

--- a/src/main/java/dnd/danverse/global/exception/ErrorCode.java
+++ b/src/main/java/dnd/danverse/global/exception/ErrorCode.java
@@ -40,6 +40,7 @@ public enum ErrorCode {
 
   // 프로필
   PROFILE_NOT_FOUND(HttpStatus.BAD_REQUEST, "P001", "프로필 등록이 필요한 서비스입니다."),
+  PROFILE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "P002", "이미 프로필이 존재합니다."),
 
   // Enum Type
   TYPE_NOT_FOUND(HttpStatus.BAD_REQUEST, "T001", "해당 타입은 존재하지 않습니다."),

--- a/src/main/java/dnd/danverse/global/security/config/SecurityConfig.java
+++ b/src/main/java/dnd/danverse/global/security/config/SecurityConfig.java
@@ -46,7 +46,7 @@ public class SecurityConfig {
         .antMatchers("/api/manager/resource").hasAuthority("ROLE_MANAGER")
         .antMatchers(HttpMethod.POST, "/api/v1/events", "/api/v1/events/apply",
             "/api/v1/events/image", "/api/v1/performances/image", "/api/v1/profiles/image", "/api/v1/performances",
-            "/api/v1/performances/{performId}/reviews")
+            "/api/v1/performances/{performId}/reviews", "/api/v1/profiles")
           .hasAuthority(userRole)
         .antMatchers(HttpMethod.DELETE, "/api/v1/events/{eventId}/cancel-apply", "/api/v1/events/{eventId}", "/api/v1/performances/{performId}")
           .hasAuthority(userRole)

--- a/src/test/java/dnd/danverse/domain/performance/repository/PerformanceRepositoryTest.java
+++ b/src/test/java/dnd/danverse/domain/performance/repository/PerformanceRepositoryTest.java
@@ -173,7 +173,6 @@ class PerformanceRepositoryTest {
   private List<Profile> createProfiles(List<Member> members, Set<ProfileGenre> profileGenres) {
     return members.stream()
         .map(member -> new Profile(member,
-                profileGenres,
                 TeamType.TEAM,
                 "테스트프로필이름",
                 new Image("imageUrl"),


### PR DESCRIPTION
### ✒️ 관련 이슈번호

- Close #147 

## 🔑 Key Changes

1. builder 생성자에서 Set<ProfileGenres>를 없앴습니다.
2. 프로필 등록 controller 메서드 구현했습니다.
3. 프로필 등록 관련 예외 처리와 에러 코드를 생성했습니다.
4. 프로필 등록 관련 순수, 복합 서비스에 로직을 추가했습니다.
5. 프로필 등록 url을 security config에 추가했습니다.
6. 프로필 등록 관련 dto를 swagger에 매핑했습니다.

## 📢 To Reviewers

-  portfolio dto를 객체로 묶어서 응답해야 할까요?