### PR TITLE
[Feat] : 자신이 작성한 공연 정보 조회 기능 구현

### DIFF
--- a/src/main/java/dnd/danverse/domain/mypage/controller/MyPageController.java
+++ b/src/main/java/dnd/danverse/domain/mypage/controller/MyPageController.java
@@ -17,6 +17,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import springfox.documentation.annotations.ApiIgnore;
 
 /**
  * 활동 내역 관련 컨트롤러.
@@ -24,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/mypage")
+@ApiIgnore
 @Api(tags = "MyPageController : 활동 내역 관련 API")
 public class MyPageController {
 

--- a/src/main/java/dnd/danverse/domain/mypage/controller/MyPageController.java
+++ b/src/main/java/dnd/danverse/domain/mypage/controller/MyPageController.java
@@ -1,7 +1,9 @@
 package dnd.danverse.domain.mypage.controller;
 
 import dnd.danverse.domain.jwt.service.SessionUser;
+import dnd.danverse.domain.mypage.dto.response.MyPerformsDto;
 import dnd.danverse.domain.mypage.dto.response.MyReviewDto;
+import dnd.danverse.domain.mypage.service.MyPerformSearchService;
 import dnd.danverse.domain.mypage.service.MyReviewSearchService;
 import dnd.danverse.global.response.DataResponse;
 import io.swagger.annotations.Api;
@@ -26,6 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class MyPageController {
 
   private final MyReviewSearchService myReviewSearchService;
+  private final MyPerformSearchService myPerformSearchService;
 
   /**
    * 사용자가 작성한 후기들을 전체 조회할 수 있는 컨트롤러.
@@ -40,6 +43,21 @@ public class MyPageController {
   public ResponseEntity<DataResponse<List<MyReviewDto>>> getMyReviews(@AuthenticationPrincipal SessionUser sessionUser) {
     List<MyReviewDto> reviews = myReviewSearchService.getMyReviews(sessionUser.getId());
     return new ResponseEntity<>(DataResponse.of(HttpStatus.OK, "작성 후기 조회 성공", reviews), HttpStatus.OK);
+  }
+
+  /**
+   * 사용자가 작성한 공연들을 전체 조회할 수 있는 컨트롤러.
+   *
+   * @param sessionUser 자신이 작성한 공연 정보 조회를 요청하는 사용자.
+   * @return 공연 전체 조회에 성공하면 200 상태코드와 함께 성공 메시지가 나타납니다.
+   */
+  @GetMapping("/performances")
+  @ApiOperation(value = "공연 조회", notes = "자신이 작성한 공연 리스트를 조회할 수 있다.")
+  @ApiImplicitParam(name = "Authorization", value = "Bearer access_token (서버에서 발급한 access_token)",
+      required = true, dataType = "string", paramType = "header")
+  public ResponseEntity<DataResponse<List<MyPerformsDto>>> searchMyPerforms(@AuthenticationPrincipal SessionUser sessionUser) {
+    List<MyPerformsDto> myPerforms = myPerformSearchService.findMyPerforms(sessionUser.getId());
+    return new ResponseEntity<>(DataResponse.of(HttpStatus.OK, "작성한 공연 조회 성공", myPerforms), HttpStatus.OK);
   }
 
 }

--- a/src/main/java/dnd/danverse/domain/mypage/dto/response/MyPerformsDto.java
+++ b/src/main/java/dnd/danverse/domain/mypage/dto/response/MyPerformsDto.java
@@ -1,0 +1,72 @@
+package dnd.danverse.domain.mypage.dto.response;
+
+import dnd.danverse.domain.performance.entity.Performance;
+import dnd.danverse.domain.profile.entity.Profile;
+import io.swagger.annotations.ApiModelProperty;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+/**
+ * 작성자가 등록한 공연 정보들을 반환하는 응답 Dto.
+ */
+@Getter
+public class MyPerformsDto {
+
+  /**
+   * 공연 고유 Id.
+   */
+  @ApiModelProperty("공연 고유 Id")
+  private final Long id;
+
+  /**
+   * 공연 등록 날짜.
+   */
+  @ApiModelProperty("공연 등록 날짜")
+  private final LocalDateTime createdDate;
+
+  /**
+   * 공연 이미지.
+   */
+  @ApiModelProperty("공연 이미지")
+  private final String imgUrl;
+
+  /**
+   * 공연 제목.
+   */
+  @ApiModelProperty("공연 제목")
+  private final String title;
+
+  /**
+   * 공연 주최자 프로필.
+   */
+  @ApiModelProperty("공연 주최자 프로필")
+  private final ProfileNameInfo profile;
+
+  /**
+   * 공연 주최자 프로필 응답 Dto.
+   */
+  @Getter
+  public static class ProfileNameInfo {
+
+    /**
+     * 공연 주최자 프로필 이름.
+     */
+    @ApiModelProperty("공연 주최자 프로필 이름")
+    private final String name;
+
+    public ProfileNameInfo(String name) {
+      this.name = name;
+    }
+  }
+
+  public MyPerformsDto(Performance performance, Profile profile) {
+    this.id = performance.getId();
+    this.createdDate = performance.getCreatedAt();
+    this.imgUrl = performance.getPerformanceImg().getImageUrl();
+    this.title = performance.getTitle();
+    this.profile = new ProfileNameInfo(profile.getProfileName());
+
+  }
+
+
+}

--- a/src/main/java/dnd/danverse/domain/mypage/service/MyPerformSearchService.java
+++ b/src/main/java/dnd/danverse/domain/mypage/service/MyPerformSearchService.java
@@ -1,0 +1,39 @@
+package dnd.danverse.domain.mypage.service;
+
+import dnd.danverse.domain.mypage.dto.response.MyPerformsDto;
+import dnd.danverse.domain.performance.entity.Performance;
+import dnd.danverse.domain.performance.service.PerformancePureService;
+import dnd.danverse.domain.profile.entity.Profile;
+import dnd.danverse.domain.profile.service.ProfilePureService;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * 자신이 등록한 공연 조회 복합 서비스.
+ */
+@Service
+@RequiredArgsConstructor
+public class MyPerformSearchService {
+
+  private final ProfilePureService profilePureService;
+  private final PerformancePureService performancePureService;
+
+  /**
+   * 자신이 작성한 공연 정보를 조회할 수 있는 서비스.
+   *
+   * @param memberId 조회를 요청하는 memberId.
+   * @return 내가 등록한 공연 목록.
+   */
+  public List<MyPerformsDto> findMyPerforms(Long memberId) {
+    Profile profile = profilePureService.retrieveProfile(memberId);
+    List<Performance> myPerforms = performancePureService.getMyPerforms(profile.getId());
+    return myPerforms.stream()
+        .map(perform -> new MyPerformsDto(perform, profile))
+        .collect(Collectors.toList());
+
+
+  }
+
+}

--- a/src/main/java/dnd/danverse/domain/performance/repository/PerformanceRepository.java
+++ b/src/main/java/dnd/danverse/domain/performance/repository/PerformanceRepository.java
@@ -22,8 +22,11 @@ public interface PerformanceRepository extends JpaRepository<Performance, Long>,
    * 공연 주최자의 프로필과 공연을 fetch join하여 반환.
    *
    * @param performId 조회하고자 하는 공연 정보글의 Id.
-   * @return Performance 를 반환함. 만약 없다면 PerformanceNotFoundException 반환.
+   * @return Performance
    */
   @Query("select p from Performance p join fetch p.profileHost where p.id = :performId")
   Optional<Performance> findPerformanceWithProfile(@Param("performId") Long performId);
+
+  @Query("select p from Performance p where p.profileHost.id = :profileId order by p.createdAt desc")
+  List<Performance> findAllByProfileId(@Param("profileId") Long profileId);
 }

--- a/src/main/java/dnd/danverse/domain/performance/service/PerformancePureService.java
+++ b/src/main/java/dnd/danverse/domain/performance/service/PerformancePureService.java
@@ -41,6 +41,12 @@ public class PerformancePureService {
         .collect(Collectors.toList());
   }
 
+  /**
+   * performId 를 통해서 주최자와 공연 정보를 함께 찾는다.
+   *
+   * @param performId 조회하려고 하는 performId.
+   * @return Performance.
+   */
   @Transactional(readOnly = true)
   public Performance getPerformanceDetail(Long performId) {
     log.info("Performance 와 주최자(profile) 를 찾기 위해 performId 인 {} 를 찾는다.", performId);
@@ -48,6 +54,12 @@ public class PerformancePureService {
         .orElseThrow(() -> new PerformanceNotFoundException(PERFORMANCE_NOT_FOUND));
   }
 
+  /**
+   * performance 를 저장한다.
+   *
+   * @param performance 저장하려고 하는 Performance.
+   * @return Performance.
+   */
   @Transactional
   public Performance createPerform(Performance performance) {
     log.info("Performance 를 저장한다. 제목 : {} ", performance.getTitle());
@@ -89,6 +101,18 @@ public class PerformancePureService {
   public void deletePerform(Performance performance) {
     log.info("performId가 {}인 공연글을 삭제합니다.", performance.getId());
     performanceRepository.delete(performance);
+  }
+
+  /**
+   * 내가 등록한 공연 정보 리스트를 조회합니다.
+   *
+   * @param profileId 조회 요청하는 사용자의 프로필 Id.
+   * @return 공연 정보 리스트.
+   */
+  @Transactional(readOnly = true)
+  public List<Performance> getMyPerforms(Long profileId) {
+    log.info("profileId 인 {} 를 통해서 공연 정보들을 찾는다. ", profileId);
+    return performanceRepository.findAllByProfileId(profileId);
   }
 
 }

--- a/src/main/java/dnd/danverse/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/dnd/danverse/domain/review/repository/ReviewRepository.java
@@ -30,6 +30,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
   Optional<Review> findReviewWithMemberById(@Param("reviewId") Long reviewId);
 
   @Query("select new dnd.danverse.domain.mypage.dto.response."
-      + "MyReviewDto(r.id, r.content, r.createdAt, pe.id, pe.title) from Review r join r.performance pe where r.member.id = :memberId")
+      + "MyReviewDto(r.id, r.content, r.createdAt, pe.id, pe.title) from Review r join r.performance pe where r.member.id = :memberId "
+      + "order by r.createdAt desc")
   List<MyReviewDto> findReviewsWithMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/dnd/danverse/global/security/config/SecurityConfig.java
+++ b/src/main/java/dnd/danverse/global/security/config/SecurityConfig.java
@@ -50,7 +50,7 @@ public class SecurityConfig {
           .hasAuthority(userRole)
         .antMatchers(HttpMethod.DELETE, "/api/v1/events/{eventId}/cancel-apply", "/api/v1/events/{eventId}", "/api/v1/performances/{performId}")
           .hasAuthority(userRole)
-        .antMatchers(HttpMethod.GET, "/api/v1/events/{eventId}/applicants", "/api/v1/mypage/performances/reviews").hasAuthority(userRole)
+        .antMatchers(HttpMethod.GET, "/api/v1/events/{eventId}/applicants", "/api/v1/mypage/performances/reviews", "/api/v1/mypage/performances").hasAuthority(userRole)
         .antMatchers(HttpMethod.PATCH, "/api/v1/events/{eventId}/accept", "/api/v1/events/deadline", "/api/v1/performances",
             "/api/v1/performances/reviews")
           .hasAuthority(userRole)


### PR DESCRIPTION
### ✒️ 관련 이슈번호

- Close #172 

## 🔑 Key Changes

1. 자신이 작성한 공연 조회 관련 컨트롤러 메서드 구현 
2. 자신이 등록한 공연 정보 응답 dto 생성
3. 자신이 등록한 공연 정보 조회 관련 복합 서비스 구현 
4. 자신이 작성한 공연 조회 url을 security config 에 추가
5. 공연 정보 조회 관련 dto를 swagger docs 에 매핑

## 📢 To Reviewers

- None