### PR TITLE
[Fix] : 이벤트 조건이 바인딩 되지 않는 경우, null로 return 하도록 수정

### DIFF
--- a/src/main/java/dnd/danverse/domain/event/entitiy/EventType.java
+++ b/src/main/java/dnd/danverse/domain/event/entitiy/EventType.java
@@ -2,6 +2,7 @@ package dnd.danverse.domain.event.entitiy;
 
 
 import static dnd.danverse.global.exception.ErrorCode.EVENT_TYPE_ENUM_NOT_SUPPORTED;
+import static org.springframework.util.StringUtils.hasText;
 
 import dnd.danverse.domain.event.exception.TypeNotSupportException;
 import lombok.Getter;
@@ -28,6 +29,10 @@ public enum EventType {
    * @return enum type
    */
   public static EventType of(String type) {
+
+    if (!hasText(type)) {
+      return null;
+    }
 
     for (EventType eventType : EventType.values()) {
       if (eventType.getType().equals(type)) {


### PR DESCRIPTION
### ✒️ 관련 이슈번호

- Close #174 

## 🔑 Key Changes

1. 필터링 조건에서 이벤트 타입이 빈 값으로 들어오는 경우, null로 return 하여 QueryDSL에서 전체 조회로 판단하도록 수정

## 📢 To Reviewers

- None 