### PR TITLE
[Feat] : 사용자가 지원한 이벤트 목록 조회 기능 구현

### DIFF
--- a/src/main/java/dnd/danverse/domain/matching/repository/EventMatchRepository.java
+++ b/src/main/java/dnd/danverse/domain/matching/repository/EventMatchRepository.java
@@ -20,4 +20,13 @@ public interface EventMatchRepository extends JpaRepository<EventMatch, Long> {
 
   @Query("SELECT DISTINCT em.event.id FROM EventMatch em WHERE em.event.id IN :eventIds AND em.isMatched = true")
   List<Long> findDistinctEventIdsByEventIdIn(@Param("eventIds") List<Long> eventIds);
+
+  /**
+   * 입력 받은 profileId 를 통해서 이벤트 지원 내역 리스트를 확인합니다.
+   *
+   * @param profileId 지원한 이벤트를 조회하려고 하는 사용자의 프로필 Id.
+   * @return List<EventMatch>
+   */
+  @Query("select em from EventMatch em join fetch em.event e where em.profileGuest.id = :profileId")
+  List<EventMatch> findAppliesEventsByProfileId(@Param("profileId") Long profileId);
 }

--- a/src/main/java/dnd/danverse/domain/matching/service/EventMatchPureService.java
+++ b/src/main/java/dnd/danverse/domain/matching/service/EventMatchPureService.java
@@ -133,5 +133,16 @@ public class EventMatchPureService {
     log.info("이벤트 지원 확인 위해 eventId: {}, profileId: {} 데이터를 통해서 찾습니다.", eventId, profileId);
     return eventMatchRepository.findByEventAndProfileGuest(eventId, profileId).isPresent();
   }
-  
+
+  /**
+   * 파라미터로 받은 profileId를 통해서 지원한 이벤트 내역을 찾습니다.
+   *
+   * @param profileId 지원한 프로필 Id.
+   * @return 지원 내역 리스트.
+   */
+  @Transactional(readOnly = true)
+  public List<EventMatch> findAppliedEvents(Long profileId) {
+    log.info("프로필 id를 통하여 지원한 event 들을 찾습니다. profileId: {}", profileId);
+    return eventMatchRepository.findAppliesEventsByProfileId(profileId);
+  }
 }

--- a/src/main/java/dnd/danverse/domain/matching/service/EventMatchPureService.java
+++ b/src/main/java/dnd/danverse/domain/matching/service/EventMatchPureService.java
@@ -142,7 +142,7 @@ public class EventMatchPureService {
    */
   @Transactional(readOnly = true)
   public List<EventMatch> findAppliedEvents(Long profileId) {
-    log.info("프로필 id를 통하여 지원한 event 들을 찾습니다. profileId: {}", profileId);
+    log.info("프로필 id를 통하여 eventMatch 들을 찾습니다. profileId: {}", profileId);
     return eventMatchRepository.findAppliesEventsByProfileId(profileId);
   }
 }

--- a/src/main/java/dnd/danverse/domain/mypage/controller/MyPageController.java
+++ b/src/main/java/dnd/danverse/domain/mypage/controller/MyPageController.java
@@ -89,7 +89,7 @@ public class MyPageController {
    * @param sessionUser 자신이 지원한 이벤트 정보 조회를 요청하는 사용자.
    * @return 사용자가 지원한 이벤트 전체 조회.
    */
-  @GetMapping("/events/apply")
+  @GetMapping("/events/applications")
   @ApiOperation(value = "지원한 이벤트 조회", notes = "자신이 지원한 이벤트 리스트를 조회할 수 있다.")
   @ApiImplicitParam(name = "Authorization", value = "Bearer access_token (서버에서 발급한 access_token)",
       required = true, dataType = "string", paramType = "header")

--- a/src/main/java/dnd/danverse/domain/mypage/controller/MyPageController.java
+++ b/src/main/java/dnd/danverse/domain/mypage/controller/MyPageController.java
@@ -1,9 +1,11 @@
 package dnd.danverse.domain.mypage.controller;
 
 import dnd.danverse.domain.jwt.service.SessionUser;
+import dnd.danverse.domain.mypage.dto.response.MyAppliesDto;
 import dnd.danverse.domain.mypage.dto.response.MyEventsDto;
 import dnd.danverse.domain.mypage.dto.response.MyPerformsDto;
 import dnd.danverse.domain.mypage.dto.response.MyReviewDto;
+import dnd.danverse.domain.mypage.service.MyAppliesSearchService;
 import dnd.danverse.domain.mypage.service.MyEventsSearchService;
 import dnd.danverse.domain.mypage.service.MyPerformSearchService;
 import dnd.danverse.domain.mypage.service.MyReviewSearchService;
@@ -34,6 +36,7 @@ public class MyPageController {
   private final MyReviewSearchService myReviewSearchService;
   private final MyPerformSearchService myPerformSearchService;
   private final MyEventsSearchService myEventsSearchService;
+  private final MyAppliesSearchService myAppliesSearchService;
 
   /**
    * 사용자가 작성한 후기들을 전체 조회할 수 있는 컨트롤러.
@@ -72,12 +75,27 @@ public class MyPageController {
    * @return 내가 작성한 이벤트 전체 조회
    */
   @GetMapping("/events")
-  @ApiOperation(value = "이벤트 조회", notes = "자신이 작성한 이벤트 리스트를 조회할 수 있다.")
+  @ApiOperation(value = "작성한 이벤트 조회", notes = "자신이 작성한 이벤트 리스트를 조회할 수 있다.")
   @ApiImplicitParam(name = "Authorization", value = "Bearer access_token (서버에서 발급한 access_token)",
       required = true, dataType = "string", paramType = "header")
   public ResponseEntity<DataResponse<List<MyEventsDto>>> searchMyEvents(@AuthenticationPrincipal SessionUser sessionUser) {
     List<MyEventsDto> myEvents = myEventsSearchService.findMyEvents(sessionUser.getId());
     return new ResponseEntity<>(DataResponse.of(HttpStatus.OK, "작성한 이벤트 조회 성공", myEvents), HttpStatus.OK);
+  }
+
+  /**
+   * 사용자가 지원한 이벤트들을 전체 조회할 수 있는 컨트롤러.
+   *
+   * @param sessionUser 자신이 지원한 이벤트 정보 조회를 요청하는 사용자.
+   * @return 사용자가 지원한 이벤트 전체 조회.
+   */
+  @GetMapping("/events/apply")
+  @ApiOperation(value = "지원한 이벤트 조회", notes = "자신이 지원한 이벤트 리스트를 조회할 수 있다.")
+  @ApiImplicitParam(name = "Authorization", value = "Bearer access_token (서버에서 발급한 access_token)",
+      required = true, dataType = "string", paramType = "header")
+  public ResponseEntity<DataResponse<List<MyAppliesDto>>> searchMyApplies(@AuthenticationPrincipal SessionUser sessionUser) {
+    List<MyAppliesDto> myApplies = myAppliesSearchService.findByApplies(sessionUser.getId());
+    return new ResponseEntity<>(DataResponse.of(HttpStatus.OK, "지원한 이벤트 조회 성공", myApplies), HttpStatus.OK);
   }
 
 }

--- a/src/main/java/dnd/danverse/domain/mypage/dto/response/MyAppliesDto.java
+++ b/src/main/java/dnd/danverse/domain/mypage/dto/response/MyAppliesDto.java
@@ -1,0 +1,71 @@
+package dnd.danverse.domain.mypage.dto.response;
+
+import dnd.danverse.domain.matching.entity.EventMatch;
+import dnd.danverse.domain.profile.entity.Profile;
+import io.swagger.annotations.ApiModelProperty;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+/**
+ * 활동 내역에서 사용자가 지원한 이벤트 목록을 조회하기 위한 응답 DTO.
+ */
+@Getter
+public class MyAppliesDto {
+
+  /**
+   * 이벤트 고유 ID.
+   */
+  @ApiModelProperty(value = "이벤트 고유 ID", example = "1")
+  private final Long id;
+
+  /**
+   * 이벤트 지원 날짜.
+   */
+  @ApiModelProperty(value = "이벤트 지원 날짜")
+  private final LocalDateTime appliedAt;
+
+  /**
+   * 지원한 이벤트 이미지 url.
+   */
+  @ApiModelProperty(value = "지원한 이벤트 이미지 url")
+  private final String imgUrl;
+
+  @ApiModelProperty(value = "지원한 이벤트 매칭 여부")
+  private final boolean isMatched;
+
+  /**
+   * 지원한 이벤트 제목.
+   */
+  @ApiModelProperty(value = "지원한 이벤트 제목")
+  private final String title;
+
+  /**
+   * 이벤트 주최자 프로필 정보 Dto.
+   */
+  @ApiModelProperty(value = "이벤트 주최자 프로필 정보 Dto")
+  private final ProfileNameInfo profile;
+
+  @Getter
+  static class ProfileNameInfo {
+
+    /**
+     * 이벤트 주최자 프로필 이름.
+     */
+    @ApiModelProperty(value = "이벤트 주최자 프로필 이름")
+    private final String name;
+
+    public ProfileNameInfo(String name) {
+      this.name = name;
+    }
+  }
+
+  public MyAppliesDto(EventMatch appliedEvent, Profile profile) {
+    this.id = appliedEvent.getEvent().getId();
+    this.appliedAt = appliedEvent.getCreatedAt();
+    this.imgUrl = appliedEvent.getEvent().getEventImg().getImageUrl();
+    this.isMatched = appliedEvent.isMatched();
+    this.title = appliedEvent.getEvent().getTitle();
+    this.profile = new ProfileNameInfo(profile.getProfileName());
+  }
+
+}

--- a/src/main/java/dnd/danverse/domain/mypage/dto/response/MyEventsDto.java
+++ b/src/main/java/dnd/danverse/domain/mypage/dto/response/MyEventsDto.java
@@ -7,7 +7,7 @@ import java.time.LocalDateTime;
 import lombok.Getter;
 
 /**
- * MyPage 에서 사용자가 참여한 이벤트 목록을 조회하기 위한 응답 DTO.
+ * MyPage 에서 사용자가 등록한 이벤트 목록을 조회하기 위한 응답 DTO.
  */
 @Getter
 public class MyEventsDto {

--- a/src/main/java/dnd/danverse/domain/mypage/service/MyAppliesSearchService.java
+++ b/src/main/java/dnd/danverse/domain/mypage/service/MyAppliesSearchService.java
@@ -1,0 +1,38 @@
+package dnd.danverse.domain.mypage.service;
+
+import dnd.danverse.domain.matching.entity.EventMatch;
+import dnd.danverse.domain.matching.service.EventMatchPureService;
+import dnd.danverse.domain.mypage.dto.response.MyAppliesDto;
+import dnd.danverse.domain.profile.entity.Profile;
+import dnd.danverse.domain.profile.service.ProfilePureService;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * 지원한 이벤트 조회 복합 서비스.
+ */
+@Service
+@RequiredArgsConstructor
+public class MyAppliesSearchService {
+
+  private final EventMatchPureService eventMatchPureService;
+  private final ProfilePureService profilePureService;
+
+  /**
+   * memberId 를 통하여 자신이 지원한 이벤트와 매칭 여부를 확인할 수 있습니다.
+   *
+   * @param memberId 조회하려고 하는 사용자의 memberId.
+   * @return 지원한 이벤트 정보를 담은 Dto 리스트.
+   */
+  public List<MyAppliesDto> findByApplies(Long memberId) {
+    Profile profile = profilePureService.retrieveProfile(memberId);
+    List<EventMatch> matches = eventMatchPureService.findAppliedEvents(profile.getId());
+    return matches.stream()
+        .map(match -> new MyAppliesDto(match, profile))
+        .collect(Collectors.toList());
+  }
+
+
+}

--- a/src/main/java/dnd/danverse/global/security/config/SecurityConfig.java
+++ b/src/main/java/dnd/danverse/global/security/config/SecurityConfig.java
@@ -53,7 +53,7 @@ public class SecurityConfig {
         .antMatchers(HttpMethod.DELETE, "/api/v1/events/{eventId}/cancel-apply", "/api/v1/events/{eventId}", "/api/v1/performances/{performId}")
           .hasAuthority(userRole)
         .antMatchers(HttpMethod.GET, "/api/v1/events/{eventId}/applicants", "/api/v1/mypage/performances/reviews", "/api/v1/mypage/performances",
-            "/api/v1/mypage/events").hasAuthority(userRole)
+            "/api/v1/mypage/events", "/api/v1/mypage/events/apply").hasAuthority(userRole)
         .antMatchers(HttpMethod.PATCH, "/api/v1/events/{eventId}/accept", "/api/v1/events/deadline", "/api/v1/performances",
             "/api/v1/performances/reviews")
           .hasAuthority(userRole)

--- a/src/main/java/dnd/danverse/global/security/config/SecurityConfig.java
+++ b/src/main/java/dnd/danverse/global/security/config/SecurityConfig.java
@@ -53,7 +53,7 @@ public class SecurityConfig {
         .antMatchers(HttpMethod.DELETE, "/api/v1/events/{eventId}/cancel-apply", "/api/v1/events/{eventId}", "/api/v1/performances/{performId}")
           .hasAuthority(userRole)
         .antMatchers(HttpMethod.GET, "/api/v1/events/{eventId}/applicants", "/api/v1/mypage/performances/reviews", "/api/v1/mypage/performances",
-            "/api/v1/mypage/events", "/api/v1/mypage/events/apply").hasAuthority(userRole)
+            "/api/v1/mypage/events", "/api/v1/mypage/events/applications").hasAuthority(userRole)
         .antMatchers(HttpMethod.PATCH, "/api/v1/events/{eventId}/accept", "/api/v1/events/deadline", "/api/v1/performances",
             "/api/v1/performances/reviews")
           .hasAuthority(userRole)


### PR DESCRIPTION
### ✒️ 관련 이슈번호

- Close #185 

## 🔑 Key Changes

1. profile id를 통하여 지원한 이벤트 내역 조회 순수, 복합 서비스 구현
2. 사용자가 지원한 이벤트 조회하는 컨트롤러 메서드 구현 
3. 사용자가 지원한 이벤트 목록 조회 정보를 담은 dto 생성
4. 등록한 이벤트 정보를 담은 dto의 java docs 수정 (참여한 -> 등록한 으로 수정했습니다)
5. 사용자 지원 이벤트 조회 url 을 security config 에 추가

## 📢 To Reviewers

- None